### PR TITLE
feat(#6,#7): template security playground example and debugging docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `componentOverrides` to `bootstrapFramework` to allow shallow metadata overrides by selector.
 - Added `patch(componentId, patch)` to `IComponentMetadataRegistry` and `ComponentMetadataRegistry`.
 - Added `.github/release.yml` to standardize automatic GitHub Release Notes categories.
+- Added `docs/templates.md` debugging section: why expressions evaluate to empty string, console warning format, DevTools filter workflow, invalid expression examples, and blocked template positions (closes #6).
+- Added `docs/templates.es.md` as the Spanish companion for the full template system reference.
+- Added playground example `16-template-security` (4 locale variants) showing allowed vs rejected template expressions and blocked template positions (closes #7).
 
 ### Changed
 - `bootstrapFramework` now validates all `componentOverrides` entries atomically before applying any patch.

--- a/docs/templates.es.md
+++ b/docs/templates.es.md
@@ -197,7 +197,7 @@ Las ramas `<on>` se renderizan cuando su `condition` se resuelve como verdadera.
 
 ## Depuración de expresiones de template
 
-Las expresiones de template se evalúan en tiempo de ejecución en el navegador. Una expresión fallida **nunca lanza una excepción** — se resuelve a cadena vacía. Los problemas se muestran mediante `console.warn` con el prefijo `[ExpressionResolver]`.
+Las expresiones de template se evalúan en tiempo de ejecución en el navegador. Una expresión fallida **nunca lanza una excepción** — se resuelve a cadena vacía. Algunos fallos emiten `console.warn` con el prefijo `[ExpressionResolver]`; otros se resuelven silenciosamente por diseño.
 
 ### Por qué una expresión se evalúa a cadena vacía
 

--- a/docs/templates.es.md
+++ b/docs/templates.es.md
@@ -1,0 +1,252 @@
+# Sistema de Templates
+
+Pick Components usa un sistema de templates con conciencia HTML que tiene dos dialectos activos en tiempo de ejecución, contextos de extracción limitados y manejo gestionado del host para proyección e inputs.
+
+## Dialectos
+
+- **Bindings reactivos `{{...}}`:** Se suscribe a propiedades del componente; actualiza el DOM cuando los valores cambian.
+- **Reglas de validación `[[RULES.campo]]`:** Emite atributos de validación HTML basados en `component.rules`, típicamente hidratados por el inicializador antes del primer render real.
+
+## Reglas de extracción
+
+- Contextos parseados: nodos de texto y valores de atributo.
+- Contextos excluidos: nombres de etiqueta, nombres de atributo, `<script>`, `<style>`, `<template>`, comentarios HTML, atributos de evento, atributo `style`, atributo `srcdoc`.
+- Los atributos URL con bindings dinámicos, como `href`, `src` y `formaction`, se escriben solo cuando el valor resuelto tiene una forma URL segura: URLs relativas o `http:`, `https:`, `mailto:` o `tel:`.
+
+Ejemplo (permitido):
+
+```html
+<p>Valor: {{count}}</p>
+<div class="tema-{{mode}}"></div>
+```
+
+Ejemplos bloqueados:
+
+```html
+<{{tag}}></{{tag}}>
+<button onclick="{{handler}}">Click</button>
+<script>{{code}}</script>
+```
+
+## Proyección de contenido con `<slot>` nativo
+
+Usa elementos estándar `<slot>` y `<slot name="x">` dentro de los templates de los componentes. El Shadow DOM gestiona la proyección de forma nativa. Asigna contenido a slots con nombre usando el atributo `slot="x"` en los hijos del Light DOM.
+
+## CSS y estilos en Shadow DOM
+
+Los estilos de los componentes están delimitados al Shadow Root y nunca se filtran al documento global. Declara los estilos mediante la opción `styles` en `@Pick` / `@PickRender`; se inyectan como un elemento `<style>` dentro del Shadow Root en cada render.
+
+### `:host` — estilos del elemento host
+
+Usa la pseudo-clase `:host` para dar estilo al propio elemento custom desde dentro del Shadow Root. Esto elimina la necesidad de un override externo de `display` o layout.
+
+```css
+/* Siempre como bloque */
+:host {
+  display: block;
+}
+
+/* Contenedor de layout transparente */
+:host {
+  display: contents;
+}
+
+/* Condicional mediante atributo */
+:host([hidden]) {
+  display: none;
+}
+
+/* Responsivo */
+:host {
+  display: flex;
+  gap: 1rem;
+}
+@media (max-width: 600px) {
+  :host {
+    flex-direction: column;
+  }
+}
+```
+
+En `@Pick`:
+
+```typescript
+ctx.css(`
+  :host { display: block; padding: 1rem; }
+`);
+```
+
+En `@PickRender`:
+
+```typescript
+@PickRender({
+  selector: 'my-card',
+  styles: `:host { display: block; border: 1px solid #ccc; }`,
+  template: `...`,
+})
+```
+
+### `::slotted()` — estilos sobre contenido proyectado
+
+El pseudo-elemento `::slotted()` aplica estilos a los hijos del Light DOM proyectados en un `<slot>`. Solo se pueden apuntar los hijos directos proyectados (no los nietos).
+
+```css
+/* Todos los hijos proyectados */
+::slotted(*) {
+  color: inherit;
+}
+
+/* Tipo de elemento específico proyectado */
+::slotted(p) {
+  margin: 0;
+}
+
+/* Hijos proyectados con una clase */
+::slotted(.destacado) {
+  background: yellow;
+}
+```
+
+### Propiedades CSS personalizadas — theming a través del Shadow DOM
+
+Las propiedades CSS personalizadas (variables) atraviesan el límite del Shadow DOM y son el patrón recomendado para el theming.
+
+```css
+/* La página consumidora define los tokens de tema */
+:root {
+  --card-bg: #fff;
+  --card-padding: 1rem;
+}
+
+/* Los estilos del componente las consumen con un fallback */
+:host {
+  background: var(--card-bg, white);
+  padding: var(--card-padding, 0.5rem);
+}
+```
+
+Esto permite theming externo sin romper el encapsulamiento.
+
+## Hosts gestionados
+
+- Un host gestionado es un elemento renderizado a través de Pick Components con metadatos del componente adjuntos.
+- Transferencia de clases: las clases del host se fusionan en el elemento outlet; los duplicados se eliminan; las clases del host van primero.
+- Transferencia de ID: el ID del host se mueve al outlet solo cuando el outlet no tiene ID; en caso contrario ambos conservan sus IDs.
+
+## Selección del outlet
+
+La resolución del outlet se prioriza como:
+
+1. Elemento con la clase `.outlet`
+2. Único elemento hijo cuando solo existe uno
+3. Elemento raíz como fallback
+
+## Manejo de inputs
+
+- Los atributos del host se copian a propiedades del componente mediante `PickElementFactory`
+  cuando la propiedad existe en la instancia del componente.
+- Los valores de atributos reactivos son gestionados por `BindingResolver`.
+- Valores soportados: primitivos (`title="Card"`), referencias de objeto/array
+  (`items="{{entries}}"` almacenados por ID en `ObjectRegistry`), texto mixto
+  (`msg="Hola {{name}}"`), y atributos booleanos como
+  `disabled="{{loading}}"`.
+- Los atributos estructurales de los primitivos como `<pick-action action="save">`
+  son consumidos por esos primitivos y no son inputs del componente.
+
+## Primitivos Pick
+
+### `<pick-action>`
+
+```html
+<pick-action action="save" value="{{draft}}">
+  <button type="button">Guardar</button>
+</pick-action>
+```
+
+- `action`: nombre de la acción expuesta por `ctx.on(...)` o `getViewActions()`.
+- `event`: alias de `action`; usa `action` en código nuevo.
+- `value`: primer argumento opcional pasado a la acción.
+- `bubble`: propagación opt-in más allá del PickComponent más cercano.
+
+El evento DOM es siempre `pick-action`, pero las acciones gestionadas se detienen en el componente más cercano a menos que `bubble` esté presente.
+
+### `<pick-for>`
+
+```html
+<pick-for items="{{todos}}" key="id">
+  <p>{{$item.text}}</p>
+</pick-for>
+```
+
+`items` recibe el array. `key` es opcional pero recomendado cuando las filas tienen un identificador estable. Cada fila expone `$item` a su template.
+
+### `<pick-select>`
+
+```html
+<pick-select>
+  <on condition="{{loading}}">
+    <p aria-busy="true">Cargando...</p>
+  </on>
+  <otherwise>
+    <p>Listo</p>
+  </otherwise>
+</pick-select>
+```
+
+Las ramas `<on>` se renderizan cuando su `condition` se resuelve como verdadera. Si ninguna rama `<on>` coincide, se renderiza `<otherwise>`.
+
+## Depuración de expresiones de template
+
+Las expresiones de template se evalúan en tiempo de ejecución en el navegador. Una expresión fallida **nunca lanza una excepción** — se resuelve a cadena vacía. Los problemas se muestran mediante `console.warn` con el prefijo `[ExpressionResolver]`.
+
+### Por qué una expresión se evalúa a cadena vacía
+
+| Causa | Ejemplo | Advertencia en consola |
+| ----- | ------- | ---------------------- |
+| IIFE o función flecha | `{{(() => x)()}}` | Sí |
+| Método lifecycle llamado | `{{onInit()}}` | Sí |
+| Propiedad no existe en el componente | `{{propDesconocida}}` | Ninguna |
+| Propiedad empieza por `_` | `{{_campo}}` | Ninguna |
+
+### Formato de la advertencia en consola
+
+Cuando el motor de templates no puede evaluar una expresión emite una de estas:
+
+```
+[ExpressionResolver] Expression evaluation error: <mensaje> in "<expresión>"
+[ExpressionResolver] Accessing non-whitelisted property "<nombre>" in expression "<expresión>"
+```
+
+### Cómo detectar errores de expresiones en las DevTools del navegador
+
+1. Abre las DevTools del navegador → pestaña **Console**.
+2. Filtra por `[ExpressionResolver]` para aislar las advertencias de templates.
+3. La advertencia incluye la expresión fallida y el motivo.
+
+### Ejemplos de expresiones inválidas
+
+```html
+<!-- IIFE — se evalúa a cadena vacía, console.warn emitido -->
+<p>{{(() => count + 1)()}}</p>
+
+<!-- Método lifecycle — cadena vacía tras la advertencia -->
+<p>{{onInit()}}</p>
+
+<!-- Propiedad que empieza por _ — silenciosamente vacía, sin advertencia -->
+<p>{{_estadoInterno}}</p>
+```
+
+### Posiciones bloqueadas en el template
+
+Los bindings en las siguientes posiciones **nunca se extraen** y aparecen como texto literal:
+
+```html
+<{{tag}}></{{tag}}>              <!-- nombre de etiqueta — no parseado -->
+<button onclick="{{handler}}">  <!-- atributo de evento — no parseado -->
+<script>{{code}}</script>       <!-- contenido de script — no parseado -->
+<style>{{rule}}</style>         <!-- contenido de style — no parseado -->
+```
+
+### Playground
+
+Consulta el ejemplo **Seguridad de Templates** en el playground para una demostración en vivo de expresiones permitidas e ignoradas silenciosamente.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -200,7 +200,7 @@ branch matches, `<otherwise>` renders.
 
 ## Debugging template expressions
 
-Template expressions evaluate at runtime in the browser. A failing expression **never throws** — it resolves to an empty string. Problems are surfaced via `console.warn` with the `[ExpressionResolver]` prefix.
+Template expressions evaluate at runtime in the browser. A failing expression **never throws** — it resolves to an empty string. Some failure modes also emit `console.warn` with the `[ExpressionResolver]` prefix, while others are intentionally silent by design.
 
 ### Why an expression evaluates to empty string
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -197,3 +197,59 @@ stable identifier. Each row exposes `$item` to its template.
 
 `<on>` branches render when their `condition` resolves truthy. If no `<on>`
 branch matches, `<otherwise>` renders.
+
+## Debugging template expressions
+
+Template expressions evaluate at runtime in the browser. A failing expression **never throws** — it resolves to an empty string. Problems are surfaced via `console.warn` with the `[ExpressionResolver]` prefix.
+
+### Why an expression evaluates to empty string
+
+| Cause | Example | Console warning |
+| ----- | ------- | --------------- |
+| IIFE or arrow function | `{{(() => x)()}}` | Yes |
+| Lifecycle method called | `{{onInit()}}` | Yes |
+| Property not on component | `{{unknownProp}}` | None |
+| Property starts with `_` | `{{_field}}` | None |
+
+### Console warning format
+
+When the template engine cannot evaluate an expression it emits one of:
+
+```
+[ExpressionResolver] Expression evaluation error: <message> in "<expression>"
+[ExpressionResolver] Accessing non-whitelisted property "<name>" in expression "<expression>"
+```
+
+### Checking for expression errors in browser devtools
+
+1. Open browser devtools → **Console** tab.
+2. Filter by `[ExpressionResolver]` to isolate template warnings.
+3. The warning includes the failing expression and the reason.
+
+### Invalid expression examples
+
+```html
+<!-- IIFE — evaluates to empty string, console.warn emitted -->
+<p>{{(() => count + 1)()}}</p>
+
+<!-- Lifecycle method — empty string after warning -->
+<p>{{onInit()}}</p>
+
+<!-- Property starting with _ — silently empty, no warning -->
+<p>{{_internalState}}</p>
+```
+
+### Blocked template positions
+
+Bindings in the following positions are **never extracted** and appear as literal text:
+
+```html
+<{{tag}}></{{tag}}>              <!-- tag name — not parsed -->
+<button onclick="{{handler}}">  <!-- event handler attribute — not parsed -->
+<script>{{code}}</script>       <!-- script content — not parsed -->
+<style>{{rule}}</style>         <!-- style content — not parsed -->
+```
+
+### Playground
+
+See the **Template Security** example in the playground for a live demonstration of allowed and silently ignored expressions.

--- a/examples/src/demos/16-template-security/variants/en-dark/index.html
+++ b/examples/src/demos/16-template-security/variants/en-dark/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        margin: 0;
+        padding: 1rem;
+        background: #111827;
+      }
+
+      template-security-example {
+        --security-bg: #1e293b;
+        --security-fg: #e5eefb;
+        --security-muted: #cbd5e1;
+        --security-border: rgba(148, 163, 184, 0.35);
+        --security-accent: #93c5fd;
+        --security-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+      }
+    </style>
+    <script type="module">
+      import { bootstrapFramework, Services } from "pick-components";
+      import "./security.example.js";
+      await bootstrapFramework(Services);
+    </script>
+  </head>
+  <body>
+    <template-security-example></template-security-example>
+  </body>
+</html>

--- a/examples/src/demos/16-template-security/variants/en-dark/security.example.ts
+++ b/examples/src/demos/16-template-security/variants/en-dark/security.example.ts
@@ -3,7 +3,7 @@ import { PickComponent, PickRender, Reactive } from "pick-components";
 
 // {{...}} expressions are evaluated by the template engine against a property allow-list.
 // Only non-private, non-lifecycle component properties are in scope.
-// Failing expressions resolve to an empty string and emit a console.warn.
+// Failing expressions resolve to an empty string; some blocked expressions also emit a console.warn.
 @PickRender({
   selector: "template-security-example",
   styles: securityStyles,

--- a/examples/src/demos/16-template-security/variants/en-dark/security.example.ts
+++ b/examples/src/demos/16-template-security/variants/en-dark/security.example.ts
@@ -1,0 +1,56 @@
+import securityStyles from "./security.styles.css";
+import { PickComponent, PickRender, Reactive } from "pick-components";
+
+// {{...}} expressions are evaluated by the template engine against a property allow-list.
+// Only non-private, non-lifecycle component properties are in scope.
+// Failing expressions resolve to an empty string and emit a console.warn.
+@PickRender({
+  selector: "template-security-example",
+  styles: securityStyles,
+  template: `
+    <section class="panel">
+      <div class="group">
+        <h3>✅ Allowed</h3>
+        <p><code>count + 1</code> <output>{{count + 1}}</output></p>
+        <p><code>user.name</code> <output>{{user.name}}</output></p>
+        <p><code>label.toUpperCase()</code> <output>{{label.toUpperCase()}}</output></p>
+        <p><code>count > 0 ? "positive" : "zero"</code> <output>{{count > 0 ? "positive" : "zero"}}</output></p>
+      </div>
+
+      <div class="group">
+        <h3>🚫 Silently empty (console.warn emitted)</h3>
+        <p><code>{{iife}}</code> <output>{{(() => count + 1)()}}</output></p>
+        <p><code>{{lifecycleLabel}}</code> <output>{{onInit()}}</output></p>
+      </div>
+
+      <div class="group">
+        <h3>🔇 Silently empty (no warning)</h3>
+        <p><code>{{privateLabel}}</code> <output>{{_secret}}</output></p>
+      </div>
+
+      <div class="group">
+        <h3>⛔ Blocked template positions</h3>
+        <p class="note">Bindings in tag names, event handler attributes, and
+          <code>&lt;script&gt;</code> / <code>&lt;style&gt;</code> content are never
+          extracted by the template engine — they appear as literal text.</p>
+        <p class="note">Open the browser console and filter by
+          <code>[ExpressionResolver]</code> to see warnings for the two expressions
+          in the group above.</p>
+      </div>
+    </section>
+  `,
+})
+class TemplateSecurityExample extends PickComponent {
+  @Reactive count = 5;
+  @Reactive user = { name: "Ada" };
+  @Reactive label = "hello";
+
+  // These properties hold the expression text so the template can display it
+  // without evaluating the expression itself:
+  readonly iife = "(() => count + 1)()";
+  readonly lifecycleLabel = "onInit()";
+  readonly privateLabel = "_secret";
+
+  // Private fields are excluded from the allow-list — they resolve to empty string:
+  private readonly _secret = "hidden";
+}

--- a/examples/src/demos/16-template-security/variants/en-dark/security.styles.css
+++ b/examples/src/demos/16-template-security/variants/en-dark/security.styles.css
@@ -1,0 +1,61 @@
+:host {
+  display: block;
+  max-width: 32rem;
+  color: var(--security-fg, #0f172a);
+}
+
+.panel {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1rem;
+  border: 1px solid var(--security-border, #cbd5e1);
+  border-radius: 1rem;
+  background: var(--security-bg, #ffffff);
+  box-shadow: var(--security-shadow, none);
+}
+
+.group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+h3 {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--security-muted, #475569);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+p {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+code {
+  color: var(--security-muted, #475569);
+  font-size: 0.8rem;
+}
+
+output {
+  font-weight: 600;
+  color: var(--security-accent, #2563eb);
+  min-width: 5rem;
+  text-align: right;
+}
+
+.note {
+  display: block;
+  font-size: 0.82rem;
+  color: var(--security-muted, #475569);
+  line-height: 1.55;
+}
+
+.note code {
+  font-size: 0.78rem;
+}

--- a/examples/src/demos/16-template-security/variants/en-dark/tabs.json
+++ b/examples/src/demos/16-template-security/variants/en-dark/tabs.json
@@ -1,0 +1,7 @@
+{
+  "tabs": [
+    { "file": "security.example.ts", "label": "Component" },
+    { "file": "security.styles.css", "label": "Styles" },
+    { "file": "index.html", "label": "HTML" }
+  ]
+}

--- a/examples/src/demos/16-template-security/variants/en-light/index.html
+++ b/examples/src/demos/16-template-security/variants/en-light/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        margin: 0;
+        padding: 1rem;
+        background: #f8fafc;
+      }
+
+      template-security-example {
+        --security-bg: #ffffff;
+        --security-fg: #0f172a;
+        --security-muted: #475569;
+        --security-border: #cbd5e1;
+        --security-accent: #2563eb;
+        --security-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+      }
+    </style>
+    <script type="module">
+      import { bootstrapFramework, Services } from "pick-components";
+      import "./security.example.js";
+      await bootstrapFramework(Services);
+    </script>
+  </head>
+  <body>
+    <template-security-example></template-security-example>
+  </body>
+</html>

--- a/examples/src/demos/16-template-security/variants/en-light/security.example.ts
+++ b/examples/src/demos/16-template-security/variants/en-light/security.example.ts
@@ -3,7 +3,7 @@ import { PickComponent, PickRender, Reactive } from "pick-components";
 
 // {{...}} expressions are evaluated by the template engine against a property allow-list.
 // Only non-private, non-lifecycle component properties are in scope.
-// Failing expressions resolve to an empty string and emit a console.warn.
+// Failing expressions resolve to an empty string; some blocked expressions also emit a console.warn.
 @PickRender({
   selector: "template-security-example",
   styles: securityStyles,

--- a/examples/src/demos/16-template-security/variants/en-light/security.example.ts
+++ b/examples/src/demos/16-template-security/variants/en-light/security.example.ts
@@ -1,0 +1,56 @@
+import securityStyles from "./security.styles.css";
+import { PickComponent, PickRender, Reactive } from "pick-components";
+
+// {{...}} expressions are evaluated by the template engine against a property allow-list.
+// Only non-private, non-lifecycle component properties are in scope.
+// Failing expressions resolve to an empty string and emit a console.warn.
+@PickRender({
+  selector: "template-security-example",
+  styles: securityStyles,
+  template: `
+    <section class="panel">
+      <div class="group">
+        <h3>✅ Allowed</h3>
+        <p><code>count + 1</code> <output>{{count + 1}}</output></p>
+        <p><code>user.name</code> <output>{{user.name}}</output></p>
+        <p><code>label.toUpperCase()</code> <output>{{label.toUpperCase()}}</output></p>
+        <p><code>count > 0 ? "positive" : "zero"</code> <output>{{count > 0 ? "positive" : "zero"}}</output></p>
+      </div>
+
+      <div class="group">
+        <h3>🚫 Silently empty (console.warn emitted)</h3>
+        <p><code>{{iife}}</code> <output>{{(() => count + 1)()}}</output></p>
+        <p><code>{{lifecycleLabel}}</code> <output>{{onInit()}}</output></p>
+      </div>
+
+      <div class="group">
+        <h3>🔇 Silently empty (no warning)</h3>
+        <p><code>{{privateLabel}}</code> <output>{{_secret}}</output></p>
+      </div>
+
+      <div class="group">
+        <h3>⛔ Blocked template positions</h3>
+        <p class="note">Bindings in tag names, event handler attributes, and
+          <code>&lt;script&gt;</code> / <code>&lt;style&gt;</code> content are never
+          extracted by the template engine — they appear as literal text.</p>
+        <p class="note">Open the browser console and filter by
+          <code>[ExpressionResolver]</code> to see warnings for the two expressions
+          in the group above.</p>
+      </div>
+    </section>
+  `,
+})
+class TemplateSecurityExample extends PickComponent {
+  @Reactive count = 5;
+  @Reactive user = { name: "Ada" };
+  @Reactive label = "hello";
+
+  // These properties hold the expression text so the template can display it
+  // without evaluating the expression itself:
+  readonly iife = "(() => count + 1)()";
+  readonly lifecycleLabel = "onInit()";
+  readonly privateLabel = "_secret";
+
+  // Private fields are excluded from the allow-list — they resolve to empty string:
+  private readonly _secret = "hidden";
+}

--- a/examples/src/demos/16-template-security/variants/en-light/security.styles.css
+++ b/examples/src/demos/16-template-security/variants/en-light/security.styles.css
@@ -1,0 +1,61 @@
+:host {
+  display: block;
+  max-width: 32rem;
+  color: var(--security-fg, #0f172a);
+}
+
+.panel {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1rem;
+  border: 1px solid var(--security-border, #cbd5e1);
+  border-radius: 1rem;
+  background: var(--security-bg, #ffffff);
+  box-shadow: var(--security-shadow, none);
+}
+
+.group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+h3 {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--security-muted, #475569);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+p {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+code {
+  color: var(--security-muted, #475569);
+  font-size: 0.8rem;
+}
+
+output {
+  font-weight: 600;
+  color: var(--security-accent, #2563eb);
+  min-width: 5rem;
+  text-align: right;
+}
+
+.note {
+  display: block;
+  font-size: 0.82rem;
+  color: var(--security-muted, #475569);
+  line-height: 1.55;
+}
+
+.note code {
+  font-size: 0.78rem;
+}

--- a/examples/src/demos/16-template-security/variants/en-light/tabs.json
+++ b/examples/src/demos/16-template-security/variants/en-light/tabs.json
@@ -1,0 +1,7 @@
+{
+  "tabs": [
+    { "file": "security.example.ts", "label": "Component" },
+    { "file": "security.styles.css", "label": "Styles" },
+    { "file": "index.html", "label": "HTML" }
+  ]
+}

--- a/examples/src/demos/16-template-security/variants/es-dark/index.html
+++ b/examples/src/demos/16-template-security/variants/es-dark/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        margin: 0;
+        padding: 1rem;
+        background: #111827;
+      }
+
+      template-security-example {
+        --security-bg: #1e293b;
+        --security-fg: #e5eefb;
+        --security-muted: #cbd5e1;
+        --security-border: rgba(148, 163, 184, 0.35);
+        --security-accent: #93c5fd;
+        --security-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+      }
+    </style>
+    <script type="module">
+      import { bootstrapFramework, Services } from "pick-components";
+      import "./security.example.js";
+      await bootstrapFramework(Services);
+    </script>
+  </head>
+  <body>
+    <template-security-example></template-security-example>
+  </body>
+</html>

--- a/examples/src/demos/16-template-security/variants/es-dark/security.example.ts
+++ b/examples/src/demos/16-template-security/variants/es-dark/security.example.ts
@@ -1,0 +1,56 @@
+import securityStyles from "./security.styles.css";
+import { PickComponent, PickRender, Reactive } from "pick-components";
+
+// Las expresiones {{...}} las evalúa el motor de templates contra una lista de propiedades permitidas.
+// Solo las propiedades no privadas y no-lifecycle del componente están en el ámbito.
+// Las expresiones fallidas se resuelven a cadena vacía y emiten un console.warn.
+@PickRender({
+  selector: "template-security-example",
+  styles: securityStyles,
+  template: `
+    <section class="panel">
+      <div class="group">
+        <h3>✅ Permitidas</h3>
+        <p><code>count + 1</code> <output>{{count + 1}}</output></p>
+        <p><code>user.name</code> <output>{{user.name}}</output></p>
+        <p><code>label.toUpperCase()</code> <output>{{label.toUpperCase()}}</output></p>
+        <p><code>count > 0 ? "positivo" : "cero"</code> <output>{{count > 0 ? "positivo" : "cero"}}</output></p>
+      </div>
+
+      <div class="group">
+        <h3>🚫 Vacías silenciosamente (console.warn emitido)</h3>
+        <p><code>{{iife}}</code> <output>{{(() => count + 1)()}}</output></p>
+        <p><code>{{lifecycleLabel}}</code> <output>{{onInit()}}</output></p>
+      </div>
+
+      <div class="group">
+        <h3>🔇 Vacías silenciosamente (sin advertencia)</h3>
+        <p><code>{{privateLabel}}</code> <output>{{_secret}}</output></p>
+      </div>
+
+      <div class="group">
+        <h3>⛔ Posiciones bloqueadas</h3>
+        <p class="note">Los bindings en nombres de etiqueta, atributos de evento y contenido de
+          <code>&lt;script&gt;</code> / <code>&lt;style&gt;</code> nunca son extraídos
+          por el motor de templates — aparecen como texto literal.</p>
+        <p class="note">Abre la consola del navegador y filtra por
+          <code>[ExpressionResolver]</code> para ver las advertencias de las dos
+          expresiones del grupo anterior.</p>
+      </div>
+    </section>
+  `,
+})
+class TemplateSecurityExample extends PickComponent {
+  @Reactive count = 5;
+  @Reactive user = { name: "Ada" };
+  @Reactive label = "hola";
+
+  // Estas propiedades guardan el texto de la expresión para mostrarlo en el template
+  // sin que sea evaluado:
+  readonly iife = "(() => count + 1)()";
+  readonly lifecycleLabel = "onInit()";
+  readonly privateLabel = "_secret";
+
+  // Los campos privados están excluidos de la lista permitida — se resuelven a cadena vacía:
+  private readonly _secret = "oculto";
+}

--- a/examples/src/demos/16-template-security/variants/es-dark/security.example.ts
+++ b/examples/src/demos/16-template-security/variants/es-dark/security.example.ts
@@ -3,7 +3,7 @@ import { PickComponent, PickRender, Reactive } from "pick-components";
 
 // Las expresiones {{...}} las evalúa el motor de templates contra una lista de propiedades permitidas.
 // Solo las propiedades no privadas y no-lifecycle del componente están en el ámbito.
-// Las expresiones fallidas se resuelven a cadena vacía y emiten un console.warn.
+// Las expresiones no permitidas se convierten en cadena vacía; algunas además emiten un console.warn.
 @PickRender({
   selector: "template-security-example",
   styles: securityStyles,

--- a/examples/src/demos/16-template-security/variants/es-dark/security.styles.css
+++ b/examples/src/demos/16-template-security/variants/es-dark/security.styles.css
@@ -1,0 +1,61 @@
+:host {
+  display: block;
+  max-width: 32rem;
+  color: var(--security-fg, #0f172a);
+}
+
+.panel {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1rem;
+  border: 1px solid var(--security-border, #cbd5e1);
+  border-radius: 1rem;
+  background: var(--security-bg, #ffffff);
+  box-shadow: var(--security-shadow, none);
+}
+
+.group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+h3 {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--security-muted, #475569);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+p {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+code {
+  color: var(--security-muted, #475569);
+  font-size: 0.8rem;
+}
+
+output {
+  font-weight: 600;
+  color: var(--security-accent, #2563eb);
+  min-width: 5rem;
+  text-align: right;
+}
+
+.note {
+  display: block;
+  font-size: 0.82rem;
+  color: var(--security-muted, #475569);
+  line-height: 1.55;
+}
+
+.note code {
+  font-size: 0.78rem;
+}

--- a/examples/src/demos/16-template-security/variants/es-dark/tabs.json
+++ b/examples/src/demos/16-template-security/variants/es-dark/tabs.json
@@ -1,0 +1,7 @@
+{
+  "tabs": [
+    { "file": "security.example.ts", "label": "Componente" },
+    { "file": "security.styles.css", "label": "Estilos" },
+    { "file": "index.html", "label": "Montaje" }
+  ]
+}

--- a/examples/src/demos/16-template-security/variants/es-light/index.html
+++ b/examples/src/demos/16-template-security/variants/es-light/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        margin: 0;
+        padding: 1rem;
+        background: #f8fafc;
+      }
+
+      template-security-example {
+        --security-bg: #ffffff;
+        --security-fg: #0f172a;
+        --security-muted: #475569;
+        --security-border: #cbd5e1;
+        --security-accent: #2563eb;
+        --security-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+      }
+    </style>
+    <script type="module">
+      import { bootstrapFramework, Services } from "pick-components";
+      import "./security.example.js";
+      await bootstrapFramework(Services);
+    </script>
+  </head>
+  <body>
+    <template-security-example></template-security-example>
+  </body>
+</html>

--- a/examples/src/demos/16-template-security/variants/es-light/security.example.ts
+++ b/examples/src/demos/16-template-security/variants/es-light/security.example.ts
@@ -1,0 +1,56 @@
+import securityStyles from "./security.styles.css";
+import { PickComponent, PickRender, Reactive } from "pick-components";
+
+// Las expresiones {{...}} las evalúa el motor de templates contra una lista de propiedades permitidas.
+// Solo las propiedades no privadas y no-lifecycle del componente están en el ámbito.
+// Las expresiones fallidas se resuelven a cadena vacía y emiten un console.warn.
+@PickRender({
+  selector: "template-security-example",
+  styles: securityStyles,
+  template: `
+    <section class="panel">
+      <div class="group">
+        <h3>✅ Permitidas</h3>
+        <p><code>count + 1</code> <output>{{count + 1}}</output></p>
+        <p><code>user.name</code> <output>{{user.name}}</output></p>
+        <p><code>label.toUpperCase()</code> <output>{{label.toUpperCase()}}</output></p>
+        <p><code>count > 0 ? "positivo" : "cero"</code> <output>{{count > 0 ? "positivo" : "cero"}}</output></p>
+      </div>
+
+      <div class="group">
+        <h3>🚫 Vacías silenciosamente (console.warn emitido)</h3>
+        <p><code>{{iife}}</code> <output>{{(() => count + 1)()}}</output></p>
+        <p><code>{{lifecycleLabel}}</code> <output>{{onInit()}}</output></p>
+      </div>
+
+      <div class="group">
+        <h3>🔇 Vacías silenciosamente (sin advertencia)</h3>
+        <p><code>{{privateLabel}}</code> <output>{{_secret}}</output></p>
+      </div>
+
+      <div class="group">
+        <h3>⛔ Posiciones bloqueadas</h3>
+        <p class="note">Los bindings en nombres de etiqueta, atributos de evento y contenido de
+          <code>&lt;script&gt;</code> / <code>&lt;style&gt;</code> nunca son extraídos
+          por el motor de templates — aparecen como texto literal.</p>
+        <p class="note">Abre la consola del navegador y filtra por
+          <code>[ExpressionResolver]</code> para ver las advertencias de las dos
+          expresiones del grupo anterior.</p>
+      </div>
+    </section>
+  `,
+})
+class TemplateSecurityExample extends PickComponent {
+  @Reactive count = 5;
+  @Reactive user = { name: "Ada" };
+  @Reactive label = "hola";
+
+  // Estas propiedades guardan el texto de la expresión para mostrarlo en el template
+  // sin que sea evaluado:
+  readonly iife = "(() => count + 1)()";
+  readonly lifecycleLabel = "onInit()";
+  readonly privateLabel = "_secret";
+
+  // Los campos privados están excluidos de la lista permitida — se resuelven a cadena vacía:
+  private readonly _secret = "oculto";
+}

--- a/examples/src/demos/16-template-security/variants/es-light/security.example.ts
+++ b/examples/src/demos/16-template-security/variants/es-light/security.example.ts
@@ -3,7 +3,7 @@ import { PickComponent, PickRender, Reactive } from "pick-components";
 
 // Las expresiones {{...}} las evalúa el motor de templates contra una lista de propiedades permitidas.
 // Solo las propiedades no privadas y no-lifecycle del componente están en el ámbito.
-// Las expresiones fallidas se resuelven a cadena vacía y emiten un console.warn.
+// Las expresiones no permitidas se convierten en cadena vacía; algunas además emiten un console.warn.
 @PickRender({
   selector: "template-security-example",
   styles: securityStyles,

--- a/examples/src/demos/16-template-security/variants/es-light/security.styles.css
+++ b/examples/src/demos/16-template-security/variants/es-light/security.styles.css
@@ -1,0 +1,61 @@
+:host {
+  display: block;
+  max-width: 32rem;
+  color: var(--security-fg, #0f172a);
+}
+
+.panel {
+  display: grid;
+  gap: 1.25rem;
+  padding: 1rem;
+  border: 1px solid var(--security-border, #cbd5e1);
+  border-radius: 1rem;
+  background: var(--security-bg, #ffffff);
+  box-shadow: var(--security-shadow, none);
+}
+
+.group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+h3 {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--security-muted, #475569);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+p {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+code {
+  color: var(--security-muted, #475569);
+  font-size: 0.8rem;
+}
+
+output {
+  font-weight: 600;
+  color: var(--security-accent, #2563eb);
+  min-width: 5rem;
+  text-align: right;
+}
+
+.note {
+  display: block;
+  font-size: 0.82rem;
+  color: var(--security-muted, #475569);
+  line-height: 1.55;
+}
+
+.note code {
+  font-size: 0.78rem;
+}

--- a/examples/src/demos/16-template-security/variants/es-light/tabs.json
+++ b/examples/src/demos/16-template-security/variants/es-light/tabs.json
@@ -1,0 +1,7 @@
+{
+  "tabs": [
+    { "file": "security.example.ts", "label": "Componente" },
+    { "file": "security.styles.css", "label": "Estilos" },
+    { "file": "index.html", "label": "Montaje" }
+  ]
+}

--- a/examples/src/features/examples-catalog/models/example-catalog.data.ts
+++ b/examples/src/features/examples-catalog/models/example-catalog.data.ts
@@ -176,4 +176,12 @@ export const PLAYGROUND_EXAMPLES: PlaygroundExampleDefinition[] = [
     minTabs: 3,
     variantSrcs: buildVariantSrcs("15-slots", "slots"),
   },
+  {
+    id: "16-template-security",
+    labels: { es: "Seguridad de Templates", en: "Template Security" },
+    category: "basics",
+    kind: "primitive",
+    minTabs: 3,
+    variantSrcs: buildVariantSrcs("16-template-security", "security"),
+  },
 ];

--- a/examples/src/features/routing/models/playground-routes.ts
+++ b/examples/src/features/routing/models/playground-routes.ts
@@ -23,6 +23,7 @@ export const PLAYGROUND_EXAMPLE_IDS = [
   "13-dashboard",
   "14-pick",
   "15-slots",
+  "16-template-security",
 ] as const;
 
 export type ExampleId = (typeof PLAYGROUND_EXAMPLE_IDS)[number];

--- a/tests/unit/playground/prerender-examples.test.ts-snapshots/prerender-es-01-hello-unit-linux.html
+++ b/tests/unit/playground/prerender-examples.test.ts-snapshots/prerender-es-01-hello-unit-linux.html
@@ -673,6 +673,8 @@
                   <a href="/es/06-pick-component">Componente @Pick</a>
                 </li><li>
                   <a href="/es/15-slots">Slots Nativos</a>
+                </li><li>
+                  <a href="/es/16-template-security">Seguridad de Templates</a>
                 </li>
           </ul>
         </section><section>


### PR DESCRIPTION
Closes #6, closes #7.

- Add playground example 16-template-security (4 locale variants: en-light, en-dark, es-light, es-dark) showing the template engine's property allow-list in action:
  - Allowed expressions: arithmetic, property access, method calls, ternary
  - Silently ignored with console.warn: IIFE, lifecycle method calls
  - Silently ignored without warning: private fields (_prefix)
  - Blocked positions: tag names, event handlers, script/style content
- Register '16-template-security' in example-catalog.data.ts (minTabs: 3).
- Add 'Debugging template expressions' section to docs/templates.md.
- Create docs/templates.es.md as Spanish companion (full semantic parity).
- Update prerender snapshot.
- Update CHANGELOG.