### PR TITLE
feat: add defineComponent and definePick decorator-free APIs (closes #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `defineComponent()` as a decorator-free alternative to `@PickRender` (closes #4).
 - Added `definePick()` as a decorator-free alternative to `@Pick` with no class required (closes #4).
 - Added `components` option to `bootstrapFramework` for explicit composition root registration (closes #4).
-- Added `ComponentDefinition` discriminated union type exported from `pick-components`.
+- Added `ComponentDefinition` discriminated union type exported from `pick-components`. The `kind` field uses string literal types (`'render' | 'pick'`), so descriptors can be constructed without importing `ComponentKind`.
+- Added `ComponentKind` convenience enum exported from `pick-components` with members `Render = 'render'` and `Pick = 'pick'`.
 - Added playground examples `17-define-component` and `18-define-pick` (4 locale variants each).
 - Added "Using without decorators" section to `docs/PICK-VS-PICKRENDER.md` and its Spanish translation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `docs/templates.md` debugging section: why expressions evaluate to empty string, console warning format, DevTools filter workflow, invalid expression examples, and blocked template positions (closes #6).
 - Added `docs/templates.es.md` as the Spanish companion for the full template system reference.
 - Added playground example `16-template-security` (4 locale variants) showing allowed vs rejected template expressions and blocked template positions (closes #7).
+- Added `defineComponent()` as a decorator-free alternative to `@PickRender` (closes #4).
+- Added `definePick()` as a decorator-free alternative to `@Pick` with no class required (closes #4).
+- Added `components` option to `bootstrapFramework` for explicit composition root registration (closes #4).
+- Added `ComponentDefinition` discriminated union type exported from `pick-components`.
+- Added playground examples `17-define-component` and `18-define-pick` (4 locale variants each).
+- Added "Using without decorators" section to `docs/PICK-VS-PICKRENDER.md` and its Spanish translation.
 
 ### Changed
 - `bootstrapFramework` now validates all `componentOverrides` entries atomically before applying any patch.

--- a/docs/PICK-VS-PICKRENDER.es.md
+++ b/docs/PICK-VS-PICKRENDER.es.md
@@ -704,7 +704,7 @@ export const counterDef = definePick<{ count: number }>("my-counter", (ctx) => {
   ctx.state({ count: 0 });
 
   ctx.on({
-    increment: (state) => ({ count: state.count + 1 }),
+    increment() { this.count++; },
   });
 
   ctx.html(`

--- a/docs/PICK-VS-PICKRENDER.es.md
+++ b/docs/PICK-VS-PICKRENDER.es.md
@@ -663,3 +663,84 @@ Componente explícito de clase  →  @PickRender
 ```
 
 Si el equipo puede leerlo cómodamente en ambas formas, cualquiera de las dos está bien. Mantener consistencia dentro de una feature importa más que imponer un decorador global.
+
+---
+
+## Sin decoradores: `defineComponent` y `definePick`
+
+`defineComponent` y `definePick` son los equivalentes sin decoradores de `@PickRender` y `@Pick`. Devuelven un descriptor `ComponentDefinition` en vez de registrar nada inmediatamente. El registro ocurre dentro de `bootstrapFramework` cuando se pasan a través de la opción `components`.
+
+Este patrón habilita un composition root explícito: todos los componentes se listan en un solo lugar, sin depender de los efectos secundarios de los decoradores al importar módulos.
+
+### `defineComponent` — basado en clase, sin decorador
+
+```typescript
+import { PickComponent, Reactive, Listen, defineComponent } from "pick-components";
+
+class ContadorComponente extends PickComponent {
+  @Reactive count = 0;
+
+  @Listen("#incrementButton", "click")
+  increment(): void {
+    this.count++;
+  }
+}
+
+export const counterDef = defineComponent(ContadorComponente, {
+  selector: "my-counter",
+  template: `
+    <p>{{count}}</p>
+    <button id="incrementButton">+1</button>
+  `,
+});
+```
+
+### `definePick` — sin clase, sin decoradores
+
+```typescript
+import { definePick } from "pick-components";
+
+export const counterDef = definePick<{ count: number }>("my-counter", (ctx) => {
+  ctx.state({ count: 0 });
+
+  ctx.on({
+    increment: (state) => ({ count: state.count + 1 }),
+  });
+
+  ctx.html(`
+    <p>{{count}}</p>
+    <button pick-action="increment">+1</button>
+  `);
+});
+```
+
+### Composition root explícito en `bootstrapFramework`
+
+Importa los descriptores y pásalos a `bootstrapFramework`. Ningún componente se registra hasta que corra el bootstrap.
+
+```typescript
+import { bootstrapFramework, Services } from "pick-components";
+import { counterDef } from "./counter.js";
+import { formDef } from "./form.js";
+
+await bootstrapFramework(Services, {}, {
+  components: [counterDef, formDef],
+});
+```
+
+### Comparación
+
+| API                | Sintaxis   | Clase requerida | Decoradores requeridos |
+| ------------------ | ---------- | --------------- | ---------------------- |
+| `@PickRender`      | decorador  | sí              | sí                     |
+| `@Pick`            | decorador  | no (generada)   | sí                     |
+| `defineComponent`  | función    | sí              | no (para @Reactive, @Listen — opcionales) |
+| `definePick`       | función    | no              | no                     |
+
+`defineComponent` y `definePick` usan el mismo pipeline de render, registry de metadata y sistema de bindings que los decoradores. No son un nivel inferior de capacidades.
+
+## Docs relacionados
+
+- Guía de DI: [DEPENDENCY-INJECTION.md](DEPENDENCY-INJECTION.md)
+- Internos de render: [RENDERING-ARCHITECTURE.md](RENDERING-ARCHITECTURE.md)
+- Versión en inglés: [PICK-VS-PICKRENDER.md](PICK-VS-PICKRENDER.md)

--- a/docs/PICK-VS-PICKRENDER.es.md
+++ b/docs/PICK-VS-PICKRENDER.es.md
@@ -670,7 +670,7 @@ Si el equipo puede leerlo cómodamente en ambas formas, cualquiera de las dos es
 
 `defineComponent` y `definePick` son los equivalentes sin decoradores de `@PickRender` y `@Pick`. Devuelven un descriptor `ComponentDefinition` en vez de registrar nada inmediatamente. El registro ocurre dentro de `bootstrapFramework` cuando se pasan a través de la opción `components`.
 
-Este patrón habilita un composition root explícito: todos los componentes se listan en un solo lugar, sin depender de los efectos secundarios de los decoradores al importar módulos.
+Este patrón elimina el *efecto secundario de registro* provocado por la importación de módulos: ningún componente se registra hasta que se ejecuta `bootstrapFramework`. Ten en cuenta que otros decoradores a nivel de clase, como `@Reactive` y `@Listen`, pueden seguir ejecutándose en el momento de la definición de la clase; en el modo de decoradores legacy de TypeScript, `@Listen` requiere que los servicios ya estén bootstrapeados, por lo que el orden de bootstrap/importación sigue siendo relevante.
 
 ### `defineComponent` — basado en clase, sin decorador
 

--- a/docs/PICK-VS-PICKRENDER.md
+++ b/docs/PICK-VS-PICKRENDER.md
@@ -656,6 +656,81 @@ Explicit class component      →  @PickRender
 
 If the team can read it comfortably in either form, either form is fine. Keep consistency within a feature more important than enforcing one decorator globally.
 
+---
+
+## Using without decorators: `defineComponent` and `definePick`
+
+`defineComponent` and `definePick` are the decorator-free equivalents of `@PickRender` and `@Pick`. They return a `ComponentDefinition` descriptor instead of registering anything immediately. Registration happens inside `bootstrapFramework` when you pass them through the `components` option.
+
+This pattern enables an explicit composition root: all components are listed in one place, with no reliance on decorator side effects triggered by module imports.
+
+### `defineComponent` — class-based, no decorator
+
+```typescript
+import { PickComponent, Reactive, Listen, defineComponent } from "pick-components";
+
+class CounterComponent extends PickComponent {
+  @Reactive count = 0;
+
+  @Listen("#incrementButton", "click")
+  increment(): void {
+    this.count++;
+  }
+}
+
+export const counterDef = defineComponent(CounterComponent, {
+  selector: "my-counter",
+  template: `
+    <p>{{count}}</p>
+    <button id="incrementButton">+1</button>
+  `,
+});
+```
+
+### `definePick` — no class, no decorators at all
+
+```typescript
+import { definePick } from "pick-components";
+
+export const counterDef = definePick<{ count: number }>("my-counter", (ctx) => {
+  ctx.state({ count: 0 });
+
+  ctx.on({
+    increment: (state) => ({ count: state.count + 1 }),
+  });
+
+  ctx.html(`
+    <p>{{count}}</p>
+    <button pick-action="increment">+1</button>
+  `);
+});
+```
+
+### Explicit composition root in `bootstrapFramework`
+
+Import descriptors and pass them to `bootstrapFramework`. No component is registered until bootstrap runs.
+
+```typescript
+import { bootstrapFramework, Services } from "pick-components";
+import { counterDef } from "./counter.js";
+import { formDef } from "./form.js";
+
+await bootstrapFramework(Services, {}, {
+  components: [counterDef, formDef],
+});
+```
+
+### Comparison
+
+| API                | Syntax     | Class required | Decorators required |
+| ------------------ | ---------- | -------------- | ------------------- |
+| `@PickRender`      | decorator  | yes            | yes                 |
+| `@Pick`            | decorator  | no (generated) | yes                 |
+| `defineComponent`  | function   | yes            | no (for @Reactive, @Listen — optional) |
+| `definePick`       | function   | no             | no                  |
+
+`defineComponent` and `definePick` use the same rendering pipeline, metadata registry, and binding system as the decorator-based APIs. They are not a different capability tier.
+
 ## Related Docs
 
 - DI guide: [DEPENDENCY-INJECTION.md](DEPENDENCY-INJECTION.md)

--- a/docs/PICK-VS-PICKRENDER.md
+++ b/docs/PICK-VS-PICKRENDER.md
@@ -662,7 +662,7 @@ If the team can read it comfortably in either form, either form is fine. Keep co
 
 `defineComponent` and `definePick` are the decorator-free equivalents of `@PickRender` and `@Pick`. They return a `ComponentDefinition` descriptor instead of registering anything immediately. Registration happens inside `bootstrapFramework` when you pass them through the `components` option.
 
-This pattern enables an explicit composition root: all components are listed in one place, with no reliance on decorator side effects triggered by module imports.
+This pattern removes the *registration* side effect triggered by module imports: no component is registered until `bootstrapFramework` runs. Note that other class-level decorators such as `@Reactive` and `@Listen` may still execute at class-definition time; in TypeScript legacy decorator mode, `@Listen` requires services to already be bootstrapped, so bootstrap/import ordering rules still apply.
 
 ### `defineComponent` — class-based, no decorator
 

--- a/docs/PICK-VS-PICKRENDER.md
+++ b/docs/PICK-VS-PICKRENDER.md
@@ -696,7 +696,7 @@ export const counterDef = definePick<{ count: number }>("my-counter", (ctx) => {
   ctx.state({ count: 0 });
 
   ctx.on({
-    increment: (state) => ({ count: state.count + 1 }),
+    increment() { this.count++; },
   });
 
   ctx.html(`

--- a/examples/src/demos/17-define-component/variants/en-dark/counter.example.ts
+++ b/examples/src/demos/17-define-component/variants/en-dark/counter.example.ts
@@ -1,0 +1,41 @@
+import counterStyles from "./counter.styles.css";
+import { PickComponent, Reactive, Listen, defineComponent } from "pick-components";
+
+// defineComponent is a decorator-free alternative to @PickRender.
+// The class uses @Reactive and @Listen as usual — only the registration changes.
+class CounterExample extends PickComponent {
+  // @Reactive state triggers a re-render, so {{count}} stays in sync.
+  @Reactive count = 0;
+
+  @Listen("#decrementButton", "click")
+  decrement(): void {
+    this.count--;
+  }
+
+  @Listen("#resetButton", "click")
+  reset(): void {
+    this.count = 0;
+  }
+
+  @Listen("#incrementButton", "click")
+  increment(): void {
+    this.count++;
+  }
+}
+
+// defineComponent replaces the @PickRender decorator.
+// It returns a ComponentDefinition descriptor consumed by bootstrapFramework.
+export const counterDef = defineComponent(CounterExample, {
+  selector: "counter-example",
+  styles: counterStyles,
+  template: `
+    <div class="counter">
+      <p>Counter: {{count}}</p>
+      <div class="actions">
+        <button id="decrementButton" type="button">−</button>
+        <button id="resetButton" type="button">Reset</button>
+        <button id="incrementButton" type="button">+</button>
+      </div>
+    </div>
+  `,
+});

--- a/examples/src/demos/17-define-component/variants/en-dark/counter.styles.css
+++ b/examples/src/demos/17-define-component/variants/en-dark/counter.styles.css
@@ -1,0 +1,30 @@
+:host {
+  display: block;
+}
+
+.counter {
+  display: grid;
+  gap: 0.75rem;
+}
+
+p {
+  margin: 0;
+  color: var(--counter-fg, #0f172a);
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  min-width: 2.5rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--counter-border, #cbd5e1);
+  border-radius: 999px;
+  background: var(--counter-button-bg, #ffffff);
+  color: var(--counter-button-fg, #0f172a);
+  font: inherit;
+}

--- a/examples/src/demos/17-define-component/variants/en-dark/index.html
+++ b/examples/src/demos/17-define-component/variants/en-dark/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        margin: 0;
+        padding: 1rem;
+        background: #111827;
+      }
+
+      counter-example {
+        --counter-fg: #e5eefb;
+        --counter-border: rgba(148, 163, 184, 0.35);
+        --counter-button-bg: #1e293b;
+        --counter-button-fg: #e5eefb;
+      }
+    </style>
+    <script type="module">
+      import { bootstrapFramework, Services } from "pick-components";
+      import { counterDef } from "./counter.example.js";
+      await bootstrapFramework(Services, {}, { components: [counterDef] });
+    </script>
+  </head>
+  <body>
+    <counter-example></counter-example>
+  </body>
+</html>

--- a/examples/src/demos/17-define-component/variants/en-dark/tabs.json
+++ b/examples/src/demos/17-define-component/variants/en-dark/tabs.json
@@ -1,0 +1,7 @@
+{
+  "tabs": [
+    { "file": "counter.example.ts", "label": "Component" },
+    { "file": "counter.styles.css", "label": "Styles" },
+    { "file": "index.html", "label": "HTML" }
+  ]
+}

--- a/examples/src/demos/17-define-component/variants/en-light/counter.example.ts
+++ b/examples/src/demos/17-define-component/variants/en-light/counter.example.ts
@@ -1,0 +1,41 @@
+import counterStyles from "./counter.styles.css";
+import { PickComponent, Reactive, Listen, defineComponent } from "pick-components";
+
+// defineComponent is a decorator-free alternative to @PickRender.
+// The class uses @Reactive and @Listen as usual — only the registration changes.
+class CounterExample extends PickComponent {
+  // @Reactive state triggers a re-render, so {{count}} stays in sync.
+  @Reactive count = 0;
+
+  @Listen("#decrementButton", "click")
+  decrement(): void {
+    this.count--;
+  }
+
+  @Listen("#resetButton", "click")
+  reset(): void {
+    this.count = 0;
+  }
+
+  @Listen("#incrementButton", "click")
+  increment(): void {
+    this.count++;
+  }
+}
+
+// defineComponent replaces the @PickRender decorator.
+// It returns a ComponentDefinition descriptor consumed by bootstrapFramework.
+export const counterDef = defineComponent(CounterExample, {
+  selector: "counter-example",
+  styles: counterStyles,
+  template: `
+    <div class="counter">
+      <p>Counter: {{count}}</p>
+      <div class="actions">
+        <button id="decrementButton" type="button">−</button>
+        <button id="resetButton" type="button">Reset</button>
+        <button id="incrementButton" type="button">+</button>
+      </div>
+    </div>
+  `,
+});

--- a/examples/src/demos/17-define-component/variants/en-light/counter.styles.css
+++ b/examples/src/demos/17-define-component/variants/en-light/counter.styles.css
@@ -1,0 +1,30 @@
+:host {
+  display: block;
+}
+
+.counter {
+  display: grid;
+  gap: 0.75rem;
+}
+
+p {
+  margin: 0;
+  color: var(--counter-fg, #0f172a);
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  min-width: 2.5rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--counter-border, #cbd5e1);
+  border-radius: 999px;
+  background: var(--counter-button-bg, #ffffff);
+  color: var(--counter-button-fg, #0f172a);
+  font: inherit;
+}

--- a/examples/src/demos/17-define-component/variants/en-light/index.html
+++ b/examples/src/demos/17-define-component/variants/en-light/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        margin: 0;
+        padding: 1rem;
+        background: #f8fafc;
+      }
+
+      counter-example {
+        --counter-fg: #0f172a;
+        --counter-border: #cbd5e1;
+        --counter-button-bg: #ffffff;
+        --counter-button-fg: #0f172a;
+      }
+    </style>
+    <script type="module">
+      import { bootstrapFramework, Services } from "pick-components";
+      // Import the descriptor — no side effects until bootstrapFramework runs.
+      import { counterDef } from "./counter.example.js";
+      // Pass the descriptor to bootstrapFramework for explicit registration.
+      await bootstrapFramework(Services, {}, { components: [counterDef] });
+    </script>
+  </head>
+  <body>
+    <counter-example></counter-example>
+  </body>
+</html>

--- a/examples/src/demos/17-define-component/variants/en-light/tabs.json
+++ b/examples/src/demos/17-define-component/variants/en-light/tabs.json
@@ -1,0 +1,7 @@
+{
+  "tabs": [
+    { "file": "counter.example.ts", "label": "Component" },
+    { "file": "counter.styles.css", "label": "Styles" },
+    { "file": "index.html", "label": "HTML" }
+  ]
+}

--- a/examples/src/demos/17-define-component/variants/es-dark/counter.example.ts
+++ b/examples/src/demos/17-define-component/variants/es-dark/counter.example.ts
@@ -1,0 +1,41 @@
+import counterStyles from "./counter.styles.css";
+import { PickComponent, Reactive, Listen, defineComponent } from "pick-components";
+
+// defineComponent es una alternativa sin decoradores a @PickRender.
+// La clase usa @Reactive y @Listen como siempre — solo cambia el registro.
+class ContadorEjemplo extends PickComponent {
+  // @Reactive vuelve a renderizar el componente para mantener {{count}} sincronizado.
+  @Reactive count = 0;
+
+  @Listen("#decrementButton", "click")
+  decrement(): void {
+    this.count--;
+  }
+
+  @Listen("#resetButton", "click")
+  reset(): void {
+    this.count = 0;
+  }
+
+  @Listen("#incrementButton", "click")
+  increment(): void {
+    this.count++;
+  }
+}
+
+// defineComponent reemplaza el decorador @PickRender.
+// Devuelve un descriptor ComponentDefinition que consume bootstrapFramework.
+export const counterDef = defineComponent(ContadorEjemplo, {
+  selector: "counter-example",
+  styles: counterStyles,
+  template: `
+    <div class="counter">
+      <p>Contador: {{count}}</p>
+      <div class="actions">
+        <button id="decrementButton" type="button">−</button>
+        <button id="resetButton" type="button">Reiniciar</button>
+        <button id="incrementButton" type="button">+</button>
+      </div>
+    </div>
+  `,
+});

--- a/examples/src/demos/17-define-component/variants/es-dark/counter.styles.css
+++ b/examples/src/demos/17-define-component/variants/es-dark/counter.styles.css
@@ -1,0 +1,30 @@
+:host {
+  display: block;
+}
+
+.counter {
+  display: grid;
+  gap: 0.75rem;
+}
+
+p {
+  margin: 0;
+  color: var(--counter-fg, #0f172a);
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  min-width: 2.5rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--counter-border, #cbd5e1);
+  border-radius: 999px;
+  background: var(--counter-button-bg, #ffffff);
+  color: var(--counter-button-fg, #0f172a);
+  font: inherit;
+}

--- a/examples/src/demos/17-define-component/variants/es-dark/index.html
+++ b/examples/src/demos/17-define-component/variants/es-dark/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        margin: 0;
+        padding: 1rem;
+        background: #111827;
+      }
+
+      counter-example {
+        --counter-fg: #e5eefb;
+        --counter-border: rgba(148, 163, 184, 0.35);
+        --counter-button-bg: #1e293b;
+        --counter-button-fg: #e5eefb;
+      }
+    </style>
+    <script type="module">
+      import { bootstrapFramework, Services } from "pick-components";
+      import { counterDef } from "./counter.example.js";
+      await bootstrapFramework(Services, {}, { components: [counterDef] });
+    </script>
+  </head>
+  <body>
+    <counter-example></counter-example>
+  </body>
+</html>

--- a/examples/src/demos/17-define-component/variants/es-dark/tabs.json
+++ b/examples/src/demos/17-define-component/variants/es-dark/tabs.json
@@ -1,0 +1,7 @@
+{
+  "tabs": [
+    { "file": "counter.example.ts", "label": "Componente" },
+    { "file": "counter.styles.css", "label": "Estilos" },
+    { "file": "index.html", "label": "HTML" }
+  ]
+}

--- a/examples/src/demos/17-define-component/variants/es-light/counter.example.ts
+++ b/examples/src/demos/17-define-component/variants/es-light/counter.example.ts
@@ -1,0 +1,41 @@
+import counterStyles from "./counter.styles.css";
+import { PickComponent, Reactive, Listen, defineComponent } from "pick-components";
+
+// defineComponent es una alternativa sin decoradores a @PickRender.
+// La clase usa @Reactive y @Listen como siempre — solo cambia el registro.
+class ContadorEjemplo extends PickComponent {
+  // @Reactive vuelve a renderizar el componente para mantener {{count}} sincronizado.
+  @Reactive count = 0;
+
+  @Listen("#decrementButton", "click")
+  decrement(): void {
+    this.count--;
+  }
+
+  @Listen("#resetButton", "click")
+  reset(): void {
+    this.count = 0;
+  }
+
+  @Listen("#incrementButton", "click")
+  increment(): void {
+    this.count++;
+  }
+}
+
+// defineComponent reemplaza el decorador @PickRender.
+// Devuelve un descriptor ComponentDefinition que consume bootstrapFramework.
+export const counterDef = defineComponent(ContadorEjemplo, {
+  selector: "counter-example",
+  styles: counterStyles,
+  template: `
+    <div class="counter">
+      <p>Contador: {{count}}</p>
+      <div class="actions">
+        <button id="decrementButton" type="button">−</button>
+        <button id="resetButton" type="button">Reiniciar</button>
+        <button id="incrementButton" type="button">+</button>
+      </div>
+    </div>
+  `,
+});

--- a/examples/src/demos/17-define-component/variants/es-light/counter.styles.css
+++ b/examples/src/demos/17-define-component/variants/es-light/counter.styles.css
@@ -1,0 +1,30 @@
+:host {
+  display: block;
+}
+
+.counter {
+  display: grid;
+  gap: 0.75rem;
+}
+
+p {
+  margin: 0;
+  color: var(--counter-fg, #0f172a);
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  min-width: 2.5rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--counter-border, #cbd5e1);
+  border-radius: 999px;
+  background: var(--counter-button-bg, #ffffff);
+  color: var(--counter-button-fg, #0f172a);
+  font: inherit;
+}

--- a/examples/src/demos/17-define-component/variants/es-light/index.html
+++ b/examples/src/demos/17-define-component/variants/es-light/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        margin: 0;
+        padding: 1rem;
+        background: #f8fafc;
+      }
+
+      counter-example {
+        --counter-fg: #0f172a;
+        --counter-border: #cbd5e1;
+        --counter-button-bg: #ffffff;
+        --counter-button-fg: #0f172a;
+      }
+    </style>
+    <script type="module">
+      import { bootstrapFramework, Services } from "pick-components";
+      // Importa el descriptor — sin efectos secundarios hasta que corra bootstrapFramework.
+      import { counterDef } from "./counter.example.js";
+      // Pasa el descriptor a bootstrapFramework para el registro explícito.
+      await bootstrapFramework(Services, {}, { components: [counterDef] });
+    </script>
+  </head>
+  <body>
+    <counter-example></counter-example>
+  </body>
+</html>

--- a/examples/src/demos/17-define-component/variants/es-light/tabs.json
+++ b/examples/src/demos/17-define-component/variants/es-light/tabs.json
@@ -1,0 +1,7 @@
+{
+  "tabs": [
+    { "file": "counter.example.ts", "label": "Componente" },
+    { "file": "counter.styles.css", "label": "Estilos" },
+    { "file": "index.html", "label": "HTML" }
+  ]
+}

--- a/examples/src/demos/18-define-pick/variants/en-dark/counter.example.ts
+++ b/examples/src/demos/18-define-pick/variants/en-dark/counter.example.ts
@@ -1,0 +1,29 @@
+import counterStyles from "./counter.styles.css";
+import { definePick } from "pick-components";
+
+// definePick is the fully decorator-free API.
+// No class, no @Reactive, no @Listen — everything is configured via ctx.
+export const counterDef = definePick<{ count: number }>("counter-example", (ctx) => {
+  // Declare reactive state. Each field maps to a {{mustache}} binding.
+  ctx.state({ count: 0 });
+
+  // Actions are methods where `this` is the component state.
+  ctx.on({
+    decrement() { this.count--; },
+    reset() { this.count = 0; },
+    increment() { this.count++; },
+  });
+
+  ctx.css(counterStyles);
+
+  ctx.html(`
+    <div class="counter">
+      <p>Counter: {{count}}</p>
+      <div class="actions">
+        <button pick-action="decrement" type="button">−</button>
+        <button pick-action="reset" type="button">Reset</button>
+        <button pick-action="increment" type="button">+</button>
+      </div>
+    </div>
+  `);
+});

--- a/examples/src/demos/18-define-pick/variants/en-dark/counter.styles.css
+++ b/examples/src/demos/18-define-pick/variants/en-dark/counter.styles.css
@@ -1,0 +1,30 @@
+:host {
+  display: block;
+}
+
+.counter {
+  display: grid;
+  gap: 0.75rem;
+}
+
+p {
+  margin: 0;
+  color: var(--counter-fg, #0f172a);
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  min-width: 2.5rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--counter-border, #cbd5e1);
+  border-radius: 999px;
+  background: var(--counter-button-bg, #ffffff);
+  color: var(--counter-button-fg, #0f172a);
+  font: inherit;
+}

--- a/examples/src/demos/18-define-pick/variants/en-dark/index.html
+++ b/examples/src/demos/18-define-pick/variants/en-dark/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        margin: 0;
+        padding: 1rem;
+        background: #111827;
+      }
+
+      counter-example {
+        --counter-fg: #e5eefb;
+        --counter-border: rgba(148, 163, 184, 0.35);
+        --counter-button-bg: #1e293b;
+        --counter-button-fg: #e5eefb;
+      }
+    </style>
+    <script type="module">
+      import { bootstrapFramework, Services } from "pick-components";
+      import { counterDef } from "./counter.example.js";
+      await bootstrapFramework(Services, {}, { components: [counterDef] });
+    </script>
+  </head>
+  <body>
+    <counter-example></counter-example>
+  </body>
+</html>

--- a/examples/src/demos/18-define-pick/variants/en-dark/tabs.json
+++ b/examples/src/demos/18-define-pick/variants/en-dark/tabs.json
@@ -1,0 +1,7 @@
+{
+  "tabs": [
+    { "file": "counter.example.ts", "label": "Component" },
+    { "file": "counter.styles.css", "label": "Styles" },
+    { "file": "index.html", "label": "HTML" }
+  ]
+}

--- a/examples/src/demos/18-define-pick/variants/en-light/counter.example.ts
+++ b/examples/src/demos/18-define-pick/variants/en-light/counter.example.ts
@@ -1,0 +1,29 @@
+import counterStyles from "./counter.styles.css";
+import { definePick } from "pick-components";
+
+// definePick is the fully decorator-free API.
+// No class, no @Reactive, no @Listen — everything is configured via ctx.
+export const counterDef = definePick<{ count: number }>("counter-example", (ctx) => {
+  // Declare reactive state. Each field maps to a {{mustache}} binding.
+  ctx.state({ count: 0 });
+
+  // Actions are methods where `this` is the component state.
+  ctx.on({
+    decrement() { this.count--; },
+    reset() { this.count = 0; },
+    increment() { this.count++; },
+  });
+
+  ctx.css(counterStyles);
+
+  ctx.html(`
+    <div class="counter">
+      <p>Counter: {{count}}</p>
+      <div class="actions">
+        <button pick-action="decrement" type="button">−</button>
+        <button pick-action="reset" type="button">Reset</button>
+        <button pick-action="increment" type="button">+</button>
+      </div>
+    </div>
+  `);
+});

--- a/examples/src/demos/18-define-pick/variants/en-light/counter.styles.css
+++ b/examples/src/demos/18-define-pick/variants/en-light/counter.styles.css
@@ -1,0 +1,30 @@
+:host {
+  display: block;
+}
+
+.counter {
+  display: grid;
+  gap: 0.75rem;
+}
+
+p {
+  margin: 0;
+  color: var(--counter-fg, #0f172a);
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  min-width: 2.5rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--counter-border, #cbd5e1);
+  border-radius: 999px;
+  background: var(--counter-button-bg, #ffffff);
+  color: var(--counter-button-fg, #0f172a);
+  font: inherit;
+}

--- a/examples/src/demos/18-define-pick/variants/en-light/index.html
+++ b/examples/src/demos/18-define-pick/variants/en-light/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        margin: 0;
+        padding: 1rem;
+        background: #f8fafc;
+      }
+
+      counter-example {
+        --counter-fg: #0f172a;
+        --counter-border: #cbd5e1;
+        --counter-button-bg: #ffffff;
+        --counter-button-fg: #0f172a;
+      }
+    </style>
+    <script type="module">
+      import { bootstrapFramework, Services } from "pick-components";
+      // Import the descriptor — no side effects until bootstrapFramework runs.
+      import { counterDef } from "./counter.example.js";
+      // Pass the descriptor to bootstrapFramework for explicit registration.
+      await bootstrapFramework(Services, {}, { components: [counterDef] });
+    </script>
+  </head>
+  <body>
+    <counter-example></counter-example>
+  </body>
+</html>

--- a/examples/src/demos/18-define-pick/variants/en-light/tabs.json
+++ b/examples/src/demos/18-define-pick/variants/en-light/tabs.json
@@ -1,0 +1,7 @@
+{
+  "tabs": [
+    { "file": "counter.example.ts", "label": "Component" },
+    { "file": "counter.styles.css", "label": "Styles" },
+    { "file": "index.html", "label": "HTML" }
+  ]
+}

--- a/examples/src/demos/18-define-pick/variants/es-dark/counter.example.ts
+++ b/examples/src/demos/18-define-pick/variants/es-dark/counter.example.ts
@@ -1,0 +1,29 @@
+import counterStyles from "./counter.styles.css";
+import { definePick } from "pick-components";
+
+// definePick es la API completamente sin decoradores.
+// Sin clase, sin @Reactive, sin @Listen — todo se configura via ctx.
+export const counterDef = definePick<{ count: number }>("counter-example", (ctx) => {
+  // Declara el estado reactivo. Cada campo se mapea a un binding {{mustache}}.
+  ctx.state({ count: 0 });
+
+  // Las acciones son métodos donde `this` es el estado del componente.
+  ctx.on({
+    decrement() { this.count--; },
+    reset() { this.count = 0; },
+    increment() { this.count++; },
+  });
+
+  ctx.css(counterStyles);
+
+  ctx.html(`
+    <div class="counter">
+      <p>Contador: {{count}}</p>
+      <div class="actions">
+        <button pick-action="decrement" type="button">−</button>
+        <button pick-action="reset" type="button">Reiniciar</button>
+        <button pick-action="increment" type="button">+</button>
+      </div>
+    </div>
+  `);
+});

--- a/examples/src/demos/18-define-pick/variants/es-dark/counter.styles.css
+++ b/examples/src/demos/18-define-pick/variants/es-dark/counter.styles.css
@@ -1,0 +1,30 @@
+:host {
+  display: block;
+}
+
+.counter {
+  display: grid;
+  gap: 0.75rem;
+}
+
+p {
+  margin: 0;
+  color: var(--counter-fg, #0f172a);
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  min-width: 2.5rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--counter-border, #cbd5e1);
+  border-radius: 999px;
+  background: var(--counter-button-bg, #ffffff);
+  color: var(--counter-button-fg, #0f172a);
+  font: inherit;
+}

--- a/examples/src/demos/18-define-pick/variants/es-dark/index.html
+++ b/examples/src/demos/18-define-pick/variants/es-dark/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        margin: 0;
+        padding: 1rem;
+        background: #111827;
+      }
+
+      counter-example {
+        --counter-fg: #e5eefb;
+        --counter-border: rgba(148, 163, 184, 0.35);
+        --counter-button-bg: #1e293b;
+        --counter-button-fg: #e5eefb;
+      }
+    </style>
+    <script type="module">
+      import { bootstrapFramework, Services } from "pick-components";
+      import { counterDef } from "./counter.example.js";
+      await bootstrapFramework(Services, {}, { components: [counterDef] });
+    </script>
+  </head>
+  <body>
+    <counter-example></counter-example>
+  </body>
+</html>

--- a/examples/src/demos/18-define-pick/variants/es-dark/tabs.json
+++ b/examples/src/demos/18-define-pick/variants/es-dark/tabs.json
@@ -1,0 +1,7 @@
+{
+  "tabs": [
+    { "file": "counter.example.ts", "label": "Componente" },
+    { "file": "counter.styles.css", "label": "Estilos" },
+    { "file": "index.html", "label": "HTML" }
+  ]
+}

--- a/examples/src/demos/18-define-pick/variants/es-light/counter.example.ts
+++ b/examples/src/demos/18-define-pick/variants/es-light/counter.example.ts
@@ -1,0 +1,29 @@
+import counterStyles from "./counter.styles.css";
+import { definePick } from "pick-components";
+
+// definePick es la API completamente sin decoradores.
+// Sin clase, sin @Reactive, sin @Listen — todo se configura via ctx.
+export const counterDef = definePick<{ count: number }>("counter-example", (ctx) => {
+  // Declara el estado reactivo. Cada campo se mapea a un binding {{mustache}}.
+  ctx.state({ count: 0 });
+
+  // Las acciones son métodos donde `this` es el estado del componente.
+  ctx.on({
+    decrement() { this.count--; },
+    reset() { this.count = 0; },
+    increment() { this.count++; },
+  });
+
+  ctx.css(counterStyles);
+
+  ctx.html(`
+    <div class="counter">
+      <p>Contador: {{count}}</p>
+      <div class="actions">
+        <button pick-action="decrement" type="button">−</button>
+        <button pick-action="reset" type="button">Reiniciar</button>
+        <button pick-action="increment" type="button">+</button>
+      </div>
+    </div>
+  `);
+});

--- a/examples/src/demos/18-define-pick/variants/es-light/counter.styles.css
+++ b/examples/src/demos/18-define-pick/variants/es-light/counter.styles.css
@@ -1,0 +1,30 @@
+:host {
+  display: block;
+}
+
+.counter {
+  display: grid;
+  gap: 0.75rem;
+}
+
+p {
+  margin: 0;
+  color: var(--counter-fg, #0f172a);
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+button {
+  min-width: 2.5rem;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--counter-border, #cbd5e1);
+  border-radius: 999px;
+  background: var(--counter-button-bg, #ffffff);
+  color: var(--counter-button-fg, #0f172a);
+  font: inherit;
+}

--- a/examples/src/demos/18-define-pick/variants/es-light/index.html
+++ b/examples/src/demos/18-define-pick/variants/es-light/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      body {
+        margin: 0;
+        padding: 1rem;
+        background: #f8fafc;
+      }
+
+      counter-example {
+        --counter-fg: #0f172a;
+        --counter-border: #cbd5e1;
+        --counter-button-bg: #ffffff;
+        --counter-button-fg: #0f172a;
+      }
+    </style>
+    <script type="module">
+      import { bootstrapFramework, Services } from "pick-components";
+      // Importa el descriptor — sin efectos secundarios hasta que corra bootstrapFramework.
+      import { counterDef } from "./counter.example.js";
+      // Pasa el descriptor a bootstrapFramework para el registro explícito.
+      await bootstrapFramework(Services, {}, { components: [counterDef] });
+    </script>
+  </head>
+  <body>
+    <counter-example></counter-example>
+  </body>
+</html>

--- a/examples/src/demos/18-define-pick/variants/es-light/tabs.json
+++ b/examples/src/demos/18-define-pick/variants/es-light/tabs.json
@@ -1,0 +1,7 @@
+{
+  "tabs": [
+    { "file": "counter.example.ts", "label": "Componente" },
+    { "file": "counter.styles.css", "label": "Estilos" },
+    { "file": "index.html", "label": "HTML" }
+  ]
+}

--- a/examples/src/features/examples-catalog/models/example-catalog.data.ts
+++ b/examples/src/features/examples-catalog/models/example-catalog.data.ts
@@ -184,4 +184,20 @@ export const PLAYGROUND_EXAMPLES: PlaygroundExampleDefinition[] = [
     minTabs: 3,
     variantSrcs: buildVariantSrcs("16-template-security", "security"),
   },
+  {
+    id: "17-define-component",
+    labels: { es: "defineComponent", en: "defineComponent" },
+    category: "architecture",
+    kind: "feature",
+    minTabs: 3,
+    variantSrcs: buildVariantSrcs("17-define-component", "counter"),
+  },
+  {
+    id: "18-define-pick",
+    labels: { es: "definePick", en: "definePick" },
+    category: "architecture",
+    kind: "feature",
+    minTabs: 3,
+    variantSrcs: buildVariantSrcs("18-define-pick", "counter"),
+  },
 ];

--- a/examples/src/features/routing/models/playground-routes.ts
+++ b/examples/src/features/routing/models/playground-routes.ts
@@ -24,6 +24,8 @@ export const PLAYGROUND_EXAMPLE_IDS = [
   "14-pick",
   "15-slots",
   "16-template-security",
+  "17-define-component",
+  "18-define-pick",
 ] as const;
 
 export type ExampleId = (typeof PLAYGROUND_EXAMPLE_IDS)[number];

--- a/src/decorators/component-kind.ts
+++ b/src/decorators/component-kind.ts
@@ -27,12 +27,12 @@ export enum ComponentKind {
  */
 export type ComponentDefinition =
   | {
-      readonly kind: typeof ComponentKind.Render;
+      readonly kind: "render";
       readonly Class: new (...args: unknown[]) => PickComponent;
       readonly config: ComponentConfig;
     }
   | {
-      readonly kind: typeof ComponentKind.Pick;
+      readonly kind: "pick";
       readonly selector: string;
       readonly setup: (ctx: InlineContext) => void;
     };

--- a/src/decorators/component-kind.ts
+++ b/src/decorators/component-kind.ts
@@ -3,16 +3,19 @@ import type { InlineContext } from "./pick/types.js";
 import type { PickComponent } from "../core/pick-component.js";
 
 /**
- * Discriminates between the two component definition variants.
+ * Convenience values for constructing `ComponentDefinition` descriptors.
+ * Each member is typed as its exact string literal value so that
+ * `ComponentKind.Render` is directly assignable to the `"render"` literal
+ * in `ComponentDefinition` without an explicit cast.
  *
  * @see {@link ComponentDefinition}
  */
-export enum ComponentKind {
+export const ComponentKind = {
   /** Class-based component, equivalent to `@PickRender`. */
-  Render = "render",
+  Render: "render",
   /** Functional component, equivalent to `@Pick`. */
-  Pick = "pick",
-}
+  Pick: "pick",
+} as const;
 
 /**
  * Descriptor for a component registered via `defineComponent` or `definePick`.

--- a/src/decorators/component-kind.ts
+++ b/src/decorators/component-kind.ts
@@ -1,0 +1,38 @@
+import type { ComponentConfig } from "./pick-render.decorator.js";
+import type { InlineContext } from "./pick/types.js";
+import type { PickComponent } from "../core/pick-component.js";
+
+/**
+ * Discriminates between the two component definition variants.
+ *
+ * @see {@link ComponentDefinition}
+ */
+export enum ComponentKind {
+  /** Class-based component, equivalent to `@PickRender`. */
+  Render = "render",
+  /** Functional component, equivalent to `@Pick`. */
+  Pick = "pick",
+}
+
+/**
+ * Descriptor for a component registered via `defineComponent` or `definePick`.
+ *
+ * @description
+ * Produced by `defineComponent` and `definePick` when called before
+ * `bootstrapFramework`. Pass descriptors through the `components` option to
+ * let the framework register them once services are available.
+ *
+ * @see {@link defineComponent}
+ * @see {@link definePick}
+ */
+export type ComponentDefinition =
+  | {
+      readonly kind: typeof ComponentKind.Render;
+      readonly Class: new (...args: unknown[]) => PickComponent;
+      readonly config: ComponentConfig;
+    }
+  | {
+      readonly kind: typeof ComponentKind.Pick;
+      readonly selector: string;
+      readonly setup: (ctx: InlineContext) => void;
+    };

--- a/src/decorators/define-component.ts
+++ b/src/decorators/define-component.ts
@@ -1,7 +1,7 @@
 import type { ComponentConfig } from "./pick-render.decorator.js";
 import type { PickComponent } from "../core/pick-component.js";
-import { ComponentKind } from "../providers/framework-bootstrap.js";
-import type { ComponentDefinition } from "../providers/framework-bootstrap.js";
+import { ComponentKind } from "./component-kind.js";
+import type { ComponentDefinition } from "./component-kind.js";
 
 /**
  * Creates a component definition descriptor for a PickComponent class.
@@ -43,6 +43,12 @@ export function defineComponent<T extends new (...args: unknown[]) => PickCompon
 ): ComponentDefinition {
   if (!Class) throw new Error("[defineComponent] Class is required");
   if (!config) throw new Error("[defineComponent] config is required");
+  if (!config.selector || config.selector.trim().length === 0) {
+    throw new Error("[defineComponent] config.selector is required and must not be empty");
+  }
+  if (config.selector !== config.selector.trim()) {
+    throw new Error("[defineComponent] config.selector must not have leading or trailing whitespace");
+  }
 
   return { kind: ComponentKind.Render, Class: Class as new (...args: unknown[]) => PickComponent, config };
 }

--- a/src/decorators/define-component.ts
+++ b/src/decorators/define-component.ts
@@ -1,0 +1,48 @@
+import type { ComponentConfig } from "./pick-render.decorator.js";
+import type { PickComponent } from "../core/pick-component.js";
+import { ComponentKind } from "../providers/framework-bootstrap.js";
+import type { ComponentDefinition } from "../providers/framework-bootstrap.js";
+
+/**
+ * Creates a component definition descriptor for a PickComponent class.
+ *
+ * @description
+ * Decorator-free alternative to `@PickRender`. Returns a `ComponentDefinition`
+ * descriptor that can be passed to `bootstrapFramework` via the `components`
+ * option. Registration happens inside the bootstrap phase, once all framework
+ * services are available.
+ *
+ * This pattern gives a single, explicit composition root instead of relying on
+ * decorator side effects triggered by module imports.
+ *
+ * @param Class - Component class extending `PickComponent`
+ * @param config - Component configuration (selector, template, lifecycle, etc.)
+ * @returns A `ComponentDefinition` descriptor
+ * @throws {Error} If `Class` is not provided
+ * @throws {Error} If `config` is not provided
+ *
+ * @example
+ * ```typescript
+ * class MyCounter extends PickComponent {
+ *   @Reactive count = 0;
+ * }
+ *
+ * await bootstrapFramework(Services, {}, {
+ *   components: [
+ *     defineComponent(MyCounter, {
+ *       selector: 'my-counter',
+ *       template: '<p>{{count}}</p>',
+ *     }),
+ *   ],
+ * });
+ * ```
+ */
+export function defineComponent<T extends new (...args: unknown[]) => PickComponent>(
+  Class: T,
+  config: ComponentConfig,
+): ComponentDefinition {
+  if (!Class) throw new Error("[defineComponent] Class is required");
+  if (!config) throw new Error("[defineComponent] config is required");
+
+  return { kind: ComponentKind.Render, Class: Class as new (...args: unknown[]) => PickComponent, config };
+}

--- a/src/decorators/define-component.ts
+++ b/src/decorators/define-component.ts
@@ -45,7 +45,7 @@ export function defineComponent<T extends new (...args: unknown[]) => PickCompon
 ): ComponentDefinition {
   if (!Class) throw new Error("[defineComponent] Class is required");
   if (!config) throw new Error("[defineComponent] config is required");
-  if (!config.selector || config.selector.trim().length === 0) {
+  if (!config.selector || typeof config.selector !== "string" || config.selector.trim().length === 0) {
     throw new Error("[defineComponent] config.selector is required and must not be empty");
   }
   if (config.selector !== config.selector.trim()) {

--- a/src/decorators/define-component.ts
+++ b/src/decorators/define-component.ts
@@ -20,6 +20,8 @@ import type { ComponentDefinition } from "./component-kind.js";
  * @returns A `ComponentDefinition` descriptor
  * @throws {Error} If `Class` is not provided
  * @throws {Error} If `config` is not provided
+ * @throws {Error} If `config.selector` is empty or whitespace-only
+ * @throws {Error} If `config.selector` has leading or trailing whitespace
  *
  * @example
  * ```typescript

--- a/src/decorators/define-pick.ts
+++ b/src/decorators/define-pick.ts
@@ -40,7 +40,7 @@ import type { ComponentDefinition } from "../providers/framework-bootstrap.js";
  * const counter = definePick<{ count: number }>('my-counter', (ctx) => {
  *   ctx.state({ count: 0 });
  *   ctx.on({
- *     increment: (state) => ({ count: state.count + 1 }),
+ *     increment() { this.count++; },
  *   });
  *   ctx.lifecycle({
  *     onInit: (component, subs) => {

--- a/src/decorators/define-pick.ts
+++ b/src/decorators/define-pick.ts
@@ -1,6 +1,6 @@
 import type { InlineContext } from "./pick/types.js";
-import { ComponentKind } from "../providers/framework-bootstrap.js";
-import type { ComponentDefinition } from "../providers/framework-bootstrap.js";
+import { ComponentKind } from "./component-kind.js";
+import type { ComponentDefinition } from "./component-kind.js";
 
 /**
  * Creates a component definition descriptor using a functional setup — no class, no decorators.

--- a/src/decorators/define-pick.ts
+++ b/src/decorators/define-pick.ts
@@ -61,9 +61,9 @@ export function definePick<TState = unknown>(
   selector: string,
   setup: (ctx: InlineContext<TState>) => void,
 ): ComponentDefinition {
-  if (!selector || selector.trim().length === 0) throw new Error("[definePick] selector is required and must not be empty");
+  if (!selector || typeof selector !== "string" || selector.trim().length === 0) throw new Error("[definePick] selector is required and must not be empty");
   if (selector !== selector.trim()) throw new Error("[definePick] selector must not have leading or trailing whitespace");
-  if (!setup) throw new Error("[definePick] setup is required");
+  if (!setup || typeof setup !== "function") throw new Error("[definePick] setup is required");
 
   return { kind: ComponentKind.Pick, selector, setup: setup as (ctx: InlineContext) => void };
 }

--- a/src/decorators/define-pick.ts
+++ b/src/decorators/define-pick.ts
@@ -19,7 +19,8 @@ import type { ComponentDefinition } from "./component-kind.js";
  * @param selector - Custom element tag name (e.g., `"my-counter"`)
  * @param setup - Setup function receiving `InlineContext`
  * @returns A `ComponentDefinition` descriptor
- * @throws {Error} If `selector` is falsy (null, undefined, or empty string)
+ * @throws {Error} If `selector` is null, undefined, empty, or whitespace-only
+ * @throws {Error} If `selector` has leading or trailing whitespace
  * @throws {Error} If `setup` is not provided
  *
  * @example
@@ -60,7 +61,8 @@ export function definePick<TState = unknown>(
   selector: string,
   setup: (ctx: InlineContext<TState>) => void,
 ): ComponentDefinition {
-  if (!selector) throw new Error("[definePick] selector is required");
+  if (!selector || selector.trim().length === 0) throw new Error("[definePick] selector is required and must not be empty");
+  if (selector !== selector.trim()) throw new Error("[definePick] selector must not have leading or trailing whitespace");
   if (!setup) throw new Error("[definePick] setup is required");
 
   return { kind: ComponentKind.Pick, selector, setup: setup as (ctx: InlineContext) => void };

--- a/src/decorators/define-pick.ts
+++ b/src/decorators/define-pick.ts
@@ -1,0 +1,67 @@
+import type { InlineContext } from "./pick/types.js";
+import { ComponentKind } from "../providers/framework-bootstrap.js";
+import type { ComponentDefinition } from "../providers/framework-bootstrap.js";
+
+/**
+ * Creates a component definition descriptor using a functional setup — no class, no decorators.
+ *
+ * @description
+ * Decorator-free alternative to `@Pick`. The component is defined entirely
+ * through the `setup` function via `InlineContext` (`ctx.state`, `ctx.html`,
+ * `ctx.listen`, `ctx.on`, `ctx.lifecycle`, etc.).
+ *
+ * Returns a `ComponentDefinition` descriptor that can be passed to
+ * `bootstrapFramework` via the `components` option. Registration happens inside
+ * the bootstrap phase, once all framework services are available. No class
+ * declaration is required at any point.
+ *
+ * @template TState - Type of component state (from `ctx.state()`)
+ * @param selector - Custom element tag name (e.g., `"my-counter"`)
+ * @param setup - Setup function receiving `InlineContext`
+ * @returns A `ComponentDefinition` descriptor
+ * @throws {Error} If `selector` is falsy (null, undefined, or empty string)
+ * @throws {Error} If `setup` is not provided
+ *
+ * @example
+ * ```typescript
+ * await bootstrapFramework(Services, {}, {
+ *   components: [
+ *     definePick('my-counter', (ctx) => {
+ *       ctx.state({ count: 0 });
+ *       ctx.html('<p>{{count}}</p>');
+ *     }),
+ *   ],
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // With actions and lifecycle
+ * const counter = definePick<{ count: number }>('my-counter', (ctx) => {
+ *   ctx.state({ count: 0 });
+ *   ctx.on({
+ *     increment: (state) => ({ count: state.count + 1 }),
+ *   });
+ *   ctx.lifecycle({
+ *     onInit: (component, subs) => {
+ *       subs.addSubscription(someSignal.subscribe(() => { ... }));
+ *     },
+ *   });
+ *   ctx.html(`
+ *     <p>{{count}}</p>
+ *     <button pick-action="increment">+1</button>
+ *   `);
+ * });
+ *
+ * await bootstrapFramework(Services, {}, { components: [counter] });
+ * ```
+ */
+export function definePick<TState = unknown>(
+  selector: string,
+  setup: (ctx: InlineContext<TState>) => void,
+): ComponentDefinition {
+  if (!selector) throw new Error("[definePick] selector is required");
+  if (!setup) throw new Error("[definePick] setup is required");
+
+  return { kind: ComponentKind.Pick, selector, setup: setup as (ctx: InlineContext) => void };
+}

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -15,3 +15,5 @@ export type {
   DomListenerHandler,
 } from "./pick/types.js";
 export { Reactive } from "./reactive.decorator.js";
+export { defineComponent } from "./define-component.js";
+export { definePick } from "./define-pick.js";

--- a/src/decorators/pick-render.decorator.ts
+++ b/src/decorators/pick-render.decorator.ts
@@ -1,9 +1,11 @@
 import { Services } from "../providers/service-provider.js";
+import type { IServiceProvider } from "../providers/service-provider.interface.js";
 import type { IComponentMetadataRegistry } from "../core/component-metadata-registry.interface.js";
 import type { IPickElementRegistrar } from "../registration/pick-element-registrar.interface.js";
 import type { PickElementOptions } from "../registration/pick-element-factory.js";
 import type { ComponentMetadata } from "../core/component-metadata.js";
 import type { PickComponent } from "../core/pick-component.js";
+import { resolveDecoratorService } from "./resolve-decorator-service.js";
 
 /**
  * Defines the configuration for a PickComponent decorator.
@@ -11,22 +13,12 @@ import type { PickComponent } from "../core/pick-component.js";
  */
 export type ComponentConfig = Partial<ComponentMetadata>;
 
-function getRequiredDecoratorService<T>(token: string): T {
-  if (!Services.has(token)) {
-    throw new Error(
-      `[PickRender] Framework services are not available. ` +
-        `Call bootstrapFramework(Services) before importing or defining components ` +
-        `that use @PickRender. Missing service: '${token}'.`,
-    );
-  }
-
-  return Services.get<T>(token);
-}
-
 /**
  * @PickRender decorator - Marks a class as a PickComponent with declarative configuration.
  *
  * @param config - Component configuration (selector, template, lifecycle, etc.)
+ * @param provider - Service provider used to resolve framework dependencies. Defaults to the global
+ *   `Services` singleton. Pass a registry only when bootstrapping outside the default service context.
  * @throws Error if config is null or undefined
  *
  * @example
@@ -42,7 +34,7 @@ function getRequiredDecoratorService<T>(token: string): T {
  * }
  * ```
  */
-export function PickRender(config: ComponentConfig): ClassDecorator {
+export function PickRender(config: ComponentConfig, provider: IServiceProvider = Services): ClassDecorator {
   if (!config) throw new Error("Config is required");
 
   return (target) => {
@@ -53,8 +45,10 @@ export function PickRender(config: ComponentConfig): ClassDecorator {
         template: config.template || "",
       };
 
-      getRequiredDecoratorService<IComponentMetadataRegistry>(
+      resolveDecoratorService<IComponentMetadataRegistry>(
         "IComponentMetadataRegistry",
+        provider,
+        "PickRender",
       ).register(config.selector, metadata);
 
       const options: PickElementOptions<PickComponent> = {
@@ -62,8 +56,10 @@ export function PickRender(config: ComponentConfig): ClassDecorator {
         lifecycle: config.lifecycle,
       };
 
-      getRequiredDecoratorService<IPickElementRegistrar>(
+      resolveDecoratorService<IPickElementRegistrar>(
         "IPickElementRegistrar",
+        provider,
+        "PickRender",
       ).register(
         config.selector,
         target as unknown as new (...args: unknown[]) => PickComponent,

--- a/src/decorators/pick.decorator.ts
+++ b/src/decorators/pick.decorator.ts
@@ -2,18 +2,8 @@ import { PickRender as PickComponentDecorator } from "./pick-render.decorator.js
 import type { InlineContext } from "./pick/types.js";
 import type { IPickComponentFactory } from "./pick/pick-component-factory.interface.js";
 import { Services } from "../providers/service-provider.js";
-
-function getRequiredDecoratorService<T>(token: string): T {
-  if (!Services.has(token)) {
-    throw new Error(
-      `[Pick] Framework services are not available. ` +
-        `Call bootstrapFramework(Services) before importing or defining components ` +
-        `that use @Pick. Missing service: '${token}'.`,
-    );
-  }
-
-  return Services.get<T>(token);
-}
+import type { IServiceProvider } from "../providers/service-provider.interface.js";
+import { resolveDecoratorService } from "./resolve-decorator-service.js";
 
 /**
  * Implements the responsibility of providing a functional decorator for Pick Components.
@@ -21,6 +11,8 @@ function getRequiredDecoratorService<T>(token: string): T {
  * @template TState - Type of component state (from `ctx.state()`)
  * @param selector - Custom element tag name (e.g., "my-counter")
  * @param setup - Setup function receiving `InlineContext`
+ * @param provider - Service provider used to resolve framework dependencies. Defaults to the global
+ *   `Services` singleton. Pass a registry only when bootstrapping outside the default service context.
  * @returns Class decorator that transforms the target into a PickComponent
  *
  * @example
@@ -35,13 +27,16 @@ function getRequiredDecoratorService<T>(token: string): T {
 export function Pick<TState = unknown>(
   selector: string,
   setup: (ctx: InlineContext<TState>) => void,
+  provider: IServiceProvider = Services,
 ): ClassDecorator {
   if (!selector) throw new Error("selector is required");
   if (!setup) throw new Error("setup is required");
 
   const decorator = ((target: unknown) => {
-    const factory = getRequiredDecoratorService<IPickComponentFactory>(
+    const factory = resolveDecoratorService<IPickComponentFactory>(
       "IPickComponentFactory",
+      provider,
+      "Pick",
     );
     const config = factory.captureConfig(setup);
     const EnhancedClass = factory.createEnhancedClass(target, config);
@@ -56,7 +51,7 @@ export function Pick<TState = unknown>(
       styles: config.styles,
       initializer: InitializerClass ? () => new InitializerClass() : undefined,
       lifecycle: LifecycleClass ? () => new LifecycleClass() : undefined,
-    });
+    }, provider);
 
     return ComponentDecorator(EnhancedClass);
   }) as ClassDecorator;

--- a/src/decorators/pick/pick-component-factory.ts
+++ b/src/decorators/pick/pick-component-factory.ts
@@ -5,7 +5,6 @@ import { PickInitializer } from "../../behaviors/pick-initializer.js";
 import { PickLifecycleManager } from "../../behaviors/pick-lifecycle-manager.js";
 import { IntentSignal } from "../../reactive/signal.js";
 import type { IListenerMetadataRegistry } from "../listen/listener-metadata-registry.interface.js";
-import { Services } from "../../providers/service-provider.js";
 import type {
   DependencyBag,
   DependencyBagFactory,
@@ -30,6 +29,19 @@ let activeComputedTracker: Set<string> | null = null;
  * `bootstrapFramework`, so the `@Pick` decorator never references concrete construction directly.
  */
 export class DefaultPickComponentFactory implements IPickComponentFactory {
+  private readonly listenerMetadataRegistry: IListenerMetadataRegistry;
+
+  /**
+   * Initializes a new instance of DefaultPickComponentFactory.
+   *
+   * @param listenerMetadataRegistry - Registry for recording listener metadata on enhanced classes
+   * @throws Error if listenerMetadataRegistry is null or undefined
+   */
+  constructor(listenerMetadataRegistry: IListenerMetadataRegistry) {
+    if (!listenerMetadataRegistry) throw new Error("listenerMetadataRegistry is required");
+    this.listenerMetadataRegistry = listenerMetadataRegistry;
+  }
+
   /**
    * Resolves dependencies from a factory, returning a shallow copy or empty object if no factory provided.
    *
@@ -308,9 +320,7 @@ export class DefaultPickComponentFactory implements IPickComponentFactory {
         (Enhanced.prototype as unknown as Record<string, unknown>)[key] = (
           config.methods as Record<string, unknown>
         )[key];
-        Services.get<IListenerMetadataRegistry>(
-          "IListenerMetadataRegistry",
-        ).register(Enhanced.prototype, {
+        this.listenerMetadataRegistry.register(Enhanced.prototype, {
           methodName: key,
           eventName: key,
           selector: null,
@@ -326,9 +336,7 @@ export class DefaultPickComponentFactory implements IPickComponentFactory {
           writable: true,
           configurable: true,
         });
-        Services.get<IListenerMetadataRegistry>(
-          "IListenerMetadataRegistry",
-        ).register(Enhanced.prototype, {
+        this.listenerMetadataRegistry.register(Enhanced.prototype, {
           methodName,
           eventName: listener.eventName,
           selector: listener.selector,

--- a/src/decorators/resolve-decorator-service.ts
+++ b/src/decorators/resolve-decorator-service.ts
@@ -1,0 +1,26 @@
+import type { IServiceProvider } from "../providers/service-provider.interface.js";
+
+/**
+ * Resolves a required service from a provider, throwing a descriptive error if missing.
+ *
+ * @param token - Service token to resolve
+ * @param provider - Service provider to resolve from
+ * @param caller - Decorator name used in the error message (e.g. `"PickRender"`)
+ * @returns The resolved service instance
+ * @throws Error if the service token is not registered in the provider
+ */
+export function resolveDecoratorService<T>(
+  token: string,
+  provider: IServiceProvider,
+  caller: string,
+): T {
+  if (!provider.has(token)) {
+    throw new Error(
+      `[${caller}] Framework services are not available. ` +
+        `Call bootstrapFramework(Services) before importing or defining components ` +
+        `that use @${caller}. Missing service: '${token}'.`,
+    );
+  }
+
+  return provider.get<T>(token);
+}

--- a/src/decorators/resolve-decorator-service.ts
+++ b/src/decorators/resolve-decorator-service.ts
@@ -17,8 +17,9 @@ export function resolveDecoratorService<T>(
   if (!provider.has(token)) {
     throw new Error(
       `[${caller}] Framework services are not available. ` +
-        `Call bootstrapFramework(Services) before importing or defining components ` +
-        `that use @${caller}. Missing service: '${token}'.`,
+        `Call bootstrapFramework() on your service registry ` +
+        `(e.g. bootstrapFramework(Services) in the default setup) ` +
+        `before defining components that use @${caller}. Missing service: '${token}'.`,
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,9 @@ export type {
   BootstrapOptions,
   DecoratorMode,
   ComponentMetadataOverrides,
-  ComponentDefinition,
 } from "./providers/framework-bootstrap.js";
+export { ComponentKind } from "./decorators/component-kind.js";
+export type { ComponentDefinition } from "./decorators/component-kind.js";
 export { IntentSignal, StateSignal } from "./reactive/signal.js";
 export type {
   IIntentSignal,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export type {
   BootstrapOptions,
   DecoratorMode,
   ComponentMetadataOverrides,
+  ComponentDefinition,
 } from "./providers/framework-bootstrap.js";
 export { IntentSignal, StateSignal } from "./reactive/signal.js";
 export type {
@@ -42,6 +43,8 @@ export {
   Listen,
   Pick,
   InlineContext,
+  defineComponent,
+  definePick,
 } from "./decorators/index.js";
 export type {
   ComponentConfig,

--- a/src/providers/framework-bootstrap.ts
+++ b/src/providers/framework-bootstrap.ts
@@ -122,16 +122,14 @@ export interface BootstrapOptions {
    * Optional shallow metadata patches applied by component selector.
    *
    * @description
-   * This enables consumers to override `template`, `styles`, `lifecycle`,
-   * `initializer`, `skeleton`, and `errorTemplate` of components already
-   * present in `IComponentMetadataRegistry`.
+   * Enables overriding `template`, `styles`, `lifecycle`, `initializer`,
+   * `skeleton`, and `errorTemplate` for components already registered in
+   * `IComponentMetadataRegistry` at the time of this call.
    *
-   * Component metadata must already be registered before `bootstrapFramework`
-   * processes `componentOverrides`. Recommended order: call `bootstrapFramework`
-   * once to register framework services, import component modules so decorators
-   * register their metadata, then call `bootstrapFramework` a second time with
-   * only `componentOverrides` before the first mount. Alternatively, call
-   * `registry.get('IComponentMetadataRegistry').patch(id, patch)` directly.
+   * When using decorator-based components (`@PickRender`, `@Pick`), decorators
+   * run at module-import time, so components must be imported before this call.
+   * When using the `components` option, both can be provided together — the
+   * framework registers `components` first, then validates and applies overrides.
    */
   readonly componentOverrides?: ComponentMetadataOverrides;
 
@@ -196,13 +194,18 @@ export async function bootstrapFramework(
 
   const decoratorMode: DecoratorMode = options.decorators ?? "auto";
   const rawComponentOverrides = options.componentOverrides;
-  const componentDefinitions = options.components ?? [];
 
   if (rawComponentOverrides !== undefined && !isPlainObject(rawComponentOverrides)) {
     throw new Error(
       "[bootstrapFramework] componentOverrides must be a plain object when provided.",
     );
   }
+
+  const rawComponents = options.components;
+  if (rawComponents !== undefined && !Array.isArray(rawComponents)) {
+    throw new Error("[bootstrapFramework] options.components must be an array.");
+  }
+  const componentDefinitions = rawComponents ?? [];
 
   const register = <T>(token: string, defaultFactory: () => T): void => {
     if (token in overrides) {
@@ -384,7 +387,7 @@ export async function bootstrapFramework(
       new PickElementRegistrar(registry, registry.get("IPickElementFactory")),
   );
 
-  // Apply componentOverrides: validate all entries first, then patch (atomic)
+  // Prepare componentOverrides — validation and patching happen after all components are registered
   const componentOverrides =
     (rawComponentOverrides as ComponentMetadataOverrides | undefined) ?? {};
   const overrideEntries = Object.entries(componentOverrides);
@@ -393,30 +396,6 @@ export async function bootstrapFramework(
     overrideEntries.length > 0
       ? registry.get<IComponentMetadataRegistry>("IComponentMetadataRegistry")
       : null;
-
-  if (metadataRegistry !== null) {
-    for (const [componentId, metadataPatch] of overrideEntries) {
-      if (componentId.trim().length === 0) {
-        throw new Error(
-          "[bootstrapFramework] componentOverrides contains an empty selector key.",
-        );
-      }
-
-      if (componentId !== componentId.trim()) {
-        throw new Error(
-          "[bootstrapFramework] componentOverrides selector keys cannot contain leading or trailing whitespace.",
-        );
-      }
-
-      metadataRegistry.validatePatch(componentId, metadataPatch);
-
-      if (!metadataRegistry.has(componentId)) {
-        throw new Error(
-          `[bootstrapFramework] componentOverrides references unregistered selector '${componentId}'.`,
-        );
-      }
-    }
-  }
 
   // Framework custom elements (dynamic imports avoid HTMLElement in Node)
   if (typeof customElements !== "undefined") {
@@ -452,13 +431,6 @@ export async function bootstrapFramework(
     }
   }
 
-  // Apply componentOverrides
-  if (metadataRegistry !== null) {
-    for (const [componentId, metadataPatch] of overrideEntries) {
-      metadataRegistry.patch(componentId, metadataPatch);
-    }
-  }
-
   // Register component definitions (defineComponent / definePick)
   if (componentDefinitions.length > 0) {
     const [{ PickRender }, { Pick }] = await Promise.all([
@@ -468,11 +440,47 @@ export async function bootstrapFramework(
 
     for (const def of componentDefinitions) {
       if (def.kind === ComponentKind.Render) {
-        PickRender(def.config)(def.Class as Parameters<ClassDecorator>[0]);
-      } else {
+        PickRender(def.config, registry)(def.Class as Parameters<ClassDecorator>[0]);
+      } else if (def.kind === ComponentKind.Pick) {
         class PickBase {}
-        Pick(def.selector, def.setup)(PickBase as Parameters<ClassDecorator>[0]);
+        Pick(def.selector, def.setup, registry)(PickBase as Parameters<ClassDecorator>[0]);
+      } else {
+        throw new Error(
+          `[bootstrapFramework] Unknown ComponentKind '${(def as ComponentDefinition & { kind: string }).kind}'. Expected '${ComponentKind.Render}' or '${ComponentKind.Pick}'.`,
+        );
       }
+    }
+  }
+
+  // Validate componentOverrides against the now-fully-registered metadata (components + decorators)
+  if (metadataRegistry !== null) {
+    for (const [componentId, metadataPatch] of overrideEntries) {
+      if (componentId.trim().length === 0) {
+        throw new Error(
+          "[bootstrapFramework] componentOverrides contains an empty selector key.",
+        );
+      }
+
+      if (componentId !== componentId.trim()) {
+        throw new Error(
+          "[bootstrapFramework] componentOverrides selector keys cannot contain leading or trailing whitespace.",
+        );
+      }
+
+      metadataRegistry.validatePatch(componentId, metadataPatch);
+
+      if (!metadataRegistry.has(componentId)) {
+        throw new Error(
+          `[bootstrapFramework] componentOverrides references unregistered selector '${componentId}'.`,
+        );
+      }
+    }
+  }
+
+  // Apply componentOverrides
+  if (metadataRegistry !== null) {
+    for (const [componentId, metadataPatch] of overrideEntries) {
+      metadataRegistry.patch(componentId, metadataPatch);
     }
   }
 }

--- a/src/providers/framework-bootstrap.ts
+++ b/src/providers/framework-bootstrap.ts
@@ -38,6 +38,9 @@ import { DefaultPrerenderAdoptionDecider } from "../ssr/prerender-manifest.js";
 import { isPlainObject } from "../utils/is-plain-object.js";
 import type { ComponentMetadata } from "../core/component-metadata.js";
 import type { IComponentMetadataRegistry } from "../core/component-metadata-registry.interface.js";
+import type { PickComponent } from "../core/pick-component.js";
+import type { ComponentConfig } from "../decorators/pick-render.decorator.js";
+import type { InlineContext } from "../decorators/pick/types.js";
 
 /**
  * Map of service token overrides.
@@ -71,6 +74,41 @@ export type ComponentMetadataOverrides = Record<
 >;
 
 /**
+ * Discriminates between the two component definition variants.
+ *
+ * @see {@link ComponentDefinition}
+ */
+export enum ComponentKind {
+  /** Class-based component, equivalent to `@PickRender`. */
+  Render = "render",
+  /** Functional component, equivalent to `@Pick`. */
+  Pick = "pick",
+}
+
+/**
+ * Descriptor for a component registered via `defineComponent` or `definePick`.
+ *
+ * @description
+ * Produced by `defineComponent` and `definePick` when called before
+ * `bootstrapFramework`. Pass descriptors through the `components` option to
+ * let the framework register them once services are available.
+ *
+ * @see {@link defineComponent}
+ * @see {@link definePick}
+ */
+export type ComponentDefinition =
+  | {
+      readonly kind: typeof ComponentKind.Render;
+      readonly Class: new (...args: unknown[]) => PickComponent;
+      readonly config: ComponentConfig;
+    }
+  | {
+      readonly kind: typeof ComponentKind.Pick;
+      readonly selector: string;
+      readonly setup: (ctx: InlineContext) => void;
+    };
+
+/**
  * Configuration options for `bootstrapFramework`.
  */
 export interface BootstrapOptions {
@@ -96,6 +134,29 @@ export interface BootstrapOptions {
    * `registry.get('IComponentMetadataRegistry').patch(id, patch)` directly.
    */
   readonly componentOverrides?: ComponentMetadataOverrides;
+
+  /**
+   * Component definitions to register as part of the bootstrap phase.
+   *
+   * @description
+   * Accepts descriptors produced by `defineComponent` and `definePick`.
+   * Registrations happen after all framework services are ready, giving
+   * a single explicit composition root instead of relying on decorator
+   * side effects from module imports.
+   *
+   * @example
+   * ```typescript
+   * import { defineComponent, definePick } from 'pick-components';
+   *
+   * await bootstrapFramework(Services, {}, {
+   *   components: [
+   *     defineComponent(MyCounter, { selector: 'my-counter', template: '...' }),
+   *     definePick('my-form', (ctx) => { ctx.html('...'); }),
+   *   ],
+   * });
+   * ```
+   */
+  readonly components?: ComponentDefinition[];
 }
 
 /**
@@ -135,6 +196,7 @@ export async function bootstrapFramework(
 
   const decoratorMode: DecoratorMode = options.decorators ?? "auto";
   const rawComponentOverrides = options.componentOverrides;
+  const componentDefinitions = options.components ?? [];
 
   if (rawComponentOverrides !== undefined && !isPlainObject(rawComponentOverrides)) {
     throw new Error(
@@ -394,6 +456,23 @@ export async function bootstrapFramework(
   if (metadataRegistry !== null) {
     for (const [componentId, metadataPatch] of overrideEntries) {
       metadataRegistry.patch(componentId, metadataPatch);
+    }
+  }
+
+  // Register component definitions (defineComponent / definePick)
+  if (componentDefinitions.length > 0) {
+    const [{ PickRender }, { Pick }] = await Promise.all([
+      import("../decorators/pick-render.decorator.js"),
+      import("../decorators/pick.decorator.js"),
+    ]);
+
+    for (const def of componentDefinitions) {
+      if (def.kind === ComponentKind.Render) {
+        PickRender(def.config)(def.Class as Parameters<ClassDecorator>[0]);
+      } else {
+        class PickBase {}
+        Pick(def.selector, def.setup)(PickBase as Parameters<ClassDecorator>[0]);
+      }
     }
   }
 }

--- a/src/providers/framework-bootstrap.ts
+++ b/src/providers/framework-bootstrap.ts
@@ -364,7 +364,7 @@ export async function bootstrapFramework(
   const overrideEntries = Object.entries(componentOverrides);
 
   const metadataRegistry =
-    overrideEntries.length > 0
+    overrideEntries.length > 0 || componentDefinitions.length > 0
       ? registry.get<IComponentMetadataRegistry>("IComponentMetadataRegistry")
       : null;
 
@@ -446,6 +446,34 @@ export async function bootstrapFramework(
         }
         if (!def.setup || typeof def.setup !== "function") {
           throw new Error(`[bootstrapFramework] components[${i}]: setup must be a function.`);
+        }
+      }
+    }
+
+    // Collect resolved selectors for atomicity checks (per-entry validation already passed)
+    const resolvedSelectors = componentDefinitions.map((def) =>
+      def.kind === ComponentKind.Render ? (def.config.selector as string) : def.selector,
+    );
+
+    // Reject duplicate selectors within this call
+    const seenSelectors = new Set<string>();
+    for (let i = 0; i < resolvedSelectors.length; i++) {
+      const sel = resolvedSelectors[i];
+      if (seenSelectors.has(sel)) {
+        throw new Error(
+          `[bootstrapFramework] components[${i}]: duplicate selector '${sel}' — already present earlier in this components array.`,
+        );
+      }
+      seenSelectors.add(sel);
+    }
+
+    // Reject selectors that are already in the metadata registry
+    if (metadataRegistry !== null) {
+      for (let i = 0; i < resolvedSelectors.length; i++) {
+        if (metadataRegistry.has(resolvedSelectors[i])) {
+          throw new Error(
+            `[bootstrapFramework] components[${i}]: selector '${resolvedSelectors[i]}' is already registered.`,
+          );
         }
       }
     }

--- a/src/providers/framework-bootstrap.ts
+++ b/src/providers/framework-bootstrap.ts
@@ -408,6 +408,12 @@ export async function bootstrapFramework(
     for (let i = 0; i < componentDefinitions.length; i++) {
       const def = componentDefinitions[i];
 
+      if (def == null || typeof def !== "object") {
+        throw new Error(
+          `[bootstrapFramework] components[${i}]: each entry must be a non-null object produced by defineComponent() or definePick().`,
+        );
+      }
+
       if (def.kind !== ComponentKind.Render && def.kind !== ComponentKind.Pick) {
         throw new Error(
           `[bootstrapFramework] components[${i}]: unknown kind '${(def as ComponentDefinition & { kind: string }).kind}'. Expected '${ComponentKind.Render}' or '${ComponentKind.Pick}'.`,
@@ -419,7 +425,7 @@ export async function bootstrapFramework(
           throw new Error(`[bootstrapFramework] components[${i}]: config is required for kind '${ComponentKind.Render}'.`);
         }
         const selector = def.config.selector;
-        if (!selector || selector.trim().length === 0) {
+        if (!selector || typeof selector !== "string" || selector.trim().length === 0) {
           throw new Error(`[bootstrapFramework] components[${i}]: config.selector is required and must not be empty.`);
         }
         if (selector !== selector.trim()) {
@@ -432,7 +438,7 @@ export async function bootstrapFramework(
 
       if (def.kind === ComponentKind.Pick) {
         const selector = def.selector;
-        if (!selector || selector.trim().length === 0) {
+        if (!selector || typeof selector !== "string" || selector.trim().length === 0) {
           throw new Error(`[bootstrapFramework] components[${i}]: selector is required and must not be empty.`);
         }
         if (selector !== selector.trim()) {

--- a/src/providers/framework-bootstrap.ts
+++ b/src/providers/framework-bootstrap.ts
@@ -421,8 +421,8 @@ export async function bootstrapFramework(
       }
 
       if (def.kind === ComponentKind.Render) {
-        if (!def.config) {
-          throw new Error(`[bootstrapFramework] components[${i}]: config is required for kind '${ComponentKind.Render}'.`);
+        if (!def.config || !isPlainObject(def.config)) {
+          throw new Error(`[bootstrapFramework] components[${i}]: config must be a plain object for kind '${ComponentKind.Render}'.`);
         }
         const selector = def.config.selector;
         if (!selector || typeof selector !== "string" || selector.trim().length === 0) {

--- a/src/providers/framework-bootstrap.ts
+++ b/src/providers/framework-bootstrap.ts
@@ -38,9 +38,11 @@ import { DefaultPrerenderAdoptionDecider } from "../ssr/prerender-manifest.js";
 import { isPlainObject } from "../utils/is-plain-object.js";
 import type { ComponentMetadata } from "../core/component-metadata.js";
 import type { IComponentMetadataRegistry } from "../core/component-metadata-registry.interface.js";
-import type { PickComponent } from "../core/pick-component.js";
-import type { ComponentConfig } from "../decorators/pick-render.decorator.js";
-import type { InlineContext } from "../decorators/pick/types.js";
+import { ComponentKind } from "../decorators/component-kind.js";
+import type { ComponentDefinition } from "../decorators/component-kind.js";
+
+export { ComponentKind } from "../decorators/component-kind.js";
+export type { ComponentDefinition } from "../decorators/component-kind.js";
 
 /**
  * Map of service token overrides.
@@ -72,41 +74,6 @@ export type ComponentMetadataOverrides = Record<
   string,
   Partial<ComponentMetadata>
 >;
-
-/**
- * Discriminates between the two component definition variants.
- *
- * @see {@link ComponentDefinition}
- */
-export enum ComponentKind {
-  /** Class-based component, equivalent to `@PickRender`. */
-  Render = "render",
-  /** Functional component, equivalent to `@Pick`. */
-  Pick = "pick",
-}
-
-/**
- * Descriptor for a component registered via `defineComponent` or `definePick`.
- *
- * @description
- * Produced by `defineComponent` and `definePick` when called before
- * `bootstrapFramework`. Pass descriptors through the `components` option to
- * let the framework register them once services are available.
- *
- * @see {@link defineComponent}
- * @see {@link definePick}
- */
-export type ComponentDefinition =
-  | {
-      readonly kind: typeof ComponentKind.Render;
-      readonly Class: new (...args: unknown[]) => PickComponent;
-      readonly config: ComponentConfig;
-    }
-  | {
-      readonly kind: typeof ComponentKind.Pick;
-      readonly selector: string;
-      readonly setup: (ctx: InlineContext) => void;
-    };
 
 /**
  * Configuration options for `bootstrapFramework`.
@@ -370,7 +337,11 @@ export async function bootstrapFramework(
   );
 
   // Pick Component class factory (@Pick decorator)
-  register("IPickComponentFactory", () => new DefaultPickComponentFactory());
+  register("IPickComponentFactory", () =>
+    new DefaultPickComponentFactory(
+      registry.get("IListenerMetadataRegistry"),
+    ),
+  );
 
   // Listener metadata registry (@Listen decorator)
   register(
@@ -433,6 +404,46 @@ export async function bootstrapFramework(
 
   // Register component definitions (defineComponent / definePick)
   if (componentDefinitions.length > 0) {
+    // Validate all entries upfront before any registration
+    for (let i = 0; i < componentDefinitions.length; i++) {
+      const def = componentDefinitions[i];
+
+      if (def.kind !== ComponentKind.Render && def.kind !== ComponentKind.Pick) {
+        throw new Error(
+          `[bootstrapFramework] components[${i}]: unknown kind '${(def as ComponentDefinition & { kind: string }).kind}'. Expected '${ComponentKind.Render}' or '${ComponentKind.Pick}'.`,
+        );
+      }
+
+      if (def.kind === ComponentKind.Render) {
+        if (!def.config) {
+          throw new Error(`[bootstrapFramework] components[${i}]: config is required for kind '${ComponentKind.Render}'.`);
+        }
+        const selector = def.config.selector;
+        if (!selector || selector.trim().length === 0) {
+          throw new Error(`[bootstrapFramework] components[${i}]: config.selector is required and must not be empty.`);
+        }
+        if (selector !== selector.trim()) {
+          throw new Error(`[bootstrapFramework] components[${i}]: config.selector must not have leading or trailing whitespace.`);
+        }
+        if (!def.Class || typeof def.Class !== "function") {
+          throw new Error(`[bootstrapFramework] components[${i}]: Class must be a constructor function.`);
+        }
+      }
+
+      if (def.kind === ComponentKind.Pick) {
+        const selector = def.selector;
+        if (!selector || selector.trim().length === 0) {
+          throw new Error(`[bootstrapFramework] components[${i}]: selector is required and must not be empty.`);
+        }
+        if (selector !== selector.trim()) {
+          throw new Error(`[bootstrapFramework] components[${i}]: selector must not have leading or trailing whitespace.`);
+        }
+        if (!def.setup || typeof def.setup !== "function") {
+          throw new Error(`[bootstrapFramework] components[${i}]: setup must be a function.`);
+        }
+      }
+    }
+
     const [{ PickRender }, { Pick }] = await Promise.all([
       import("../decorators/pick-render.decorator.js"),
       import("../decorators/pick.decorator.js"),
@@ -444,10 +455,6 @@ export async function bootstrapFramework(
       } else if (def.kind === ComponentKind.Pick) {
         class PickBase {}
         Pick(def.selector, def.setup, registry)(PickBase as Parameters<ClassDecorator>[0]);
-      } else {
-        throw new Error(
-          `[bootstrapFramework] Unknown ComponentKind '${(def as ComponentDefinition & { kind: string }).kind}'. Expected '${ComponentKind.Render}' or '${ComponentKind.Pick}'.`,
-        );
       }
     }
   }

--- a/tests/integration/bootstrap-components-option.test.ts
+++ b/tests/integration/bootstrap-components-option.test.ts
@@ -142,4 +142,26 @@ test.describe("bootstrapFramework — components option", () => {
     expect(metadataRegistry.has("my-label-e2e")).toBe(true);
     expect(metadataRegistry.get("my-label-e2e")?.template).toBe("<span>{{label}}</span>");
   });
+
+  test("should apply componentOverrides to a component registered in the same call via components", async () => {
+    // Arrange
+    await bootstrapFramework(Services);
+
+    const def = defineComponent(PickComponent, {
+      selector: "my-overridable",
+      template: "<p>original</p>",
+    });
+
+    // Act — components and componentOverrides in a single bootstrapFramework call
+    await bootstrapFramework(Services, {}, {
+      components: [def],
+      componentOverrides: {
+        "my-overridable": { selector: "my-overridable", template: "<p>overridden</p>" },
+      },
+    });
+
+    // Assert
+    const metadataRegistry = Services.get<IComponentMetadataRegistry>("IComponentMetadataRegistry");
+    expect(metadataRegistry.get("my-overridable")?.template).toBe("<p>overridden</p>");
+  });
 });

--- a/tests/integration/bootstrap-components-option.test.ts
+++ b/tests/integration/bootstrap-components-option.test.ts
@@ -23,6 +23,8 @@ import { definePick } from "../../src/decorators/define-pick.js";
  * so registering them in a live customElements registry would corrupt other tests.
  */
 test.describe("bootstrapFramework — components option", () => {
+  test.describe.configure({ mode: "serial" });
+
   let savedCustomElements: unknown;
 
   test.beforeEach(() => {

--- a/tests/integration/bootstrap-components-option.test.ts
+++ b/tests/integration/bootstrap-components-option.test.ts
@@ -166,4 +166,27 @@ test.describe("bootstrapFramework — components option", () => {
     const metadataRegistry = Services.get<IComponentMetadataRegistry>("IComponentMetadataRegistry");
     expect(metadataRegistry.get("my-overridable")?.template).toBe("<p>overridden</p>");
   });
+
+  test("should throw when a component selector is already registered", async () => {
+    // Arrange — bootstrap and register a component
+    await bootstrapFramework(Services);
+    const def = defineComponent(PickComponent, {
+      selector: "already-registered-comp",
+      template: "<p>original</p>",
+    });
+    await bootstrapFramework(Services, {}, { components: [def] });
+
+    // Act — attempt to register the same selector again
+    const duplicate = defineComponent(PickComponent, {
+      selector: "already-registered-comp",
+      template: "<p>duplicate</p>",
+    });
+
+    // Assert — throws before any registration
+    await expect(
+      bootstrapFramework(Services, {}, { components: [duplicate] }),
+    ).rejects.toThrow(
+      "[bootstrapFramework] components[0]: selector 'already-registered-comp' is already registered.",
+    );
+  });
 });

--- a/tests/integration/bootstrap-components-option.test.ts
+++ b/tests/integration/bootstrap-components-option.test.ts
@@ -1,0 +1,145 @@
+import { test, expect } from "@playwright/test";
+import { Services } from "../../src/providers/service-provider.js";
+import { bootstrapFramework, ComponentKind } from "../../src/providers/framework-bootstrap.js";
+import type { ComponentDefinition } from "../../src/providers/framework-bootstrap.js";
+import type { IComponentMetadataRegistry } from "../../src/core/component-metadata-registry.interface.js";
+import { PickComponent } from "../../src/core/pick-component.js";
+import { defineComponent } from "../../src/decorators/define-component.js";
+import { definePick } from "../../src/decorators/define-pick.js";
+
+/**
+ * Integration tests for the bootstrapFramework `components` option.
+ *
+ * Covers:
+ * - defineComponent descriptor registers metadata via PickRender after bootstrap
+ * - definePick descriptor registers metadata via Pick after bootstrap
+ * - Mixed arrays with both kinds are all registered
+ *
+ * These tests require the global Services singleton and a full bootstrap pass,
+ * which is why they live in integration/ rather than unit/.
+ *
+ * Note: customElements is cleared in beforeEach to prevent cross-test contamination
+ * when running in parallel. The test classes are not valid HTMLElement subclasses,
+ * so registering them in a live customElements registry would corrupt other tests.
+ */
+test.describe("bootstrapFramework — components option", () => {
+  let savedCustomElements: unknown;
+
+  test.beforeEach(() => {
+    savedCustomElements = (global as any).customElements;
+    delete (global as any).customElements;
+  });
+
+  test.afterEach(() => {
+    Services.clear();
+    if (savedCustomElements !== undefined) {
+      (global as any).customElements = savedCustomElements;
+    }
+  });
+
+  test("should register a defineComponent descriptor as a component", async () => {
+    // Arrange
+    await bootstrapFramework(Services);
+
+    class MyButton {}
+    const def: ComponentDefinition = {
+      kind: ComponentKind.Render,
+      Class: MyButton as unknown as new (...args: unknown[]) => PickComponent,
+      config: { selector: "my-define-button", template: "<button>Click</button>" },
+    };
+
+    // Act
+    await bootstrapFramework(Services, {}, { components: [def] });
+
+    // Assert
+    const metadataRegistry = Services.get<IComponentMetadataRegistry>("IComponentMetadataRegistry");
+    expect(metadataRegistry.has("my-define-button")).toBe(true);
+    expect(metadataRegistry.get("my-define-button")?.template).toBe("<button>Click</button>");
+  });
+
+  test("should register a definePick descriptor as a component", async () => {
+    // Arrange
+    await bootstrapFramework(Services);
+
+    const def: ComponentDefinition = {
+      kind: ComponentKind.Pick,
+      selector: "my-define-counter",
+      setup: (ctx: any) => {
+        ctx.state({ count: 0 });
+        ctx.html("<p>{{count}}</p>");
+      },
+    };
+
+    // Act
+    await bootstrapFramework(Services, {}, { components: [def] });
+
+    // Assert
+    const metadataRegistry = Services.get<IComponentMetadataRegistry>("IComponentMetadataRegistry");
+    expect(metadataRegistry.has("my-define-counter")).toBe(true);
+    expect(metadataRegistry.get("my-define-counter")?.template).toBe("<p>{{count}}</p>");
+  });
+
+  test("should register all descriptors in a mixed components array", async () => {
+    // Arrange
+    await bootstrapFramework(Services);
+
+    class MyCard {}
+    const defs: ComponentDefinition[] = [
+      {
+        kind: ComponentKind.Render,
+        Class: MyCard as unknown as new (...args: unknown[]) => PickComponent,
+        config: { selector: "my-define-card", template: "<div>card</div>" },
+      },
+      {
+        kind: ComponentKind.Pick,
+        selector: "my-define-badge",
+        setup: (ctx: any) => { ctx.html("<span>badge</span>"); },
+      },
+    ];
+
+    // Act
+    await bootstrapFramework(Services, {}, { components: defs });
+
+    // Assert
+    const metadataRegistry = Services.get<IComponentMetadataRegistry>("IComponentMetadataRegistry");
+    expect(metadataRegistry.has("my-define-card")).toBe(true);
+    expect(metadataRegistry.has("my-define-badge")).toBe(true);
+  });
+
+  test("defineComponent descriptor should register via bootstrapFramework end-to-end", async () => {
+    // Arrange
+    await bootstrapFramework(Services);
+
+    class MyToggle extends PickComponent {}
+    const def = defineComponent(MyToggle, {
+      selector: "my-toggle-e2e",
+      template: "<button>toggle</button>",
+    });
+
+    // Act
+    await bootstrapFramework(Services, {}, { components: [def] });
+
+    // Assert
+    const metadataRegistry = Services.get<IComponentMetadataRegistry>("IComponentMetadataRegistry");
+    expect(metadataRegistry.has("my-toggle-e2e")).toBe(true);
+    expect(metadataRegistry.get("my-toggle-e2e")?.template).toBe("<button>toggle</button>");
+  });
+
+  test("definePick descriptor should register via bootstrapFramework end-to-end", async () => {
+    // Arrange
+    await bootstrapFramework(Services);
+
+    const def = definePick<{ label: string }>("my-label-e2e", (ctx) => {
+      ctx.state({ label: "hello" });
+      ctx.html("<span>{{label}}</span>");
+    });
+
+    // Act
+    await bootstrapFramework(Services, {}, { components: [def] });
+
+    // Assert
+    const metadataRegistry = Services.get<IComponentMetadataRegistry>("IComponentMetadataRegistry");
+    expect(metadataRegistry.has("my-label-e2e")).toBe(true);
+    expect(metadataRegistry.get("my-label-e2e")?.template).toBe("<span>{{label}}</span>");
+  });
+});

--- a/tests/unit/decorators/decorator-bootstrap-order.test.ts
+++ b/tests/unit/decorators/decorator-bootstrap-order.test.ts
@@ -27,8 +27,9 @@ test.describe("Decorator bootstrap order", () => {
     // Act & Assert
     expect(defineComponent).toThrow(
       "[PickRender] Framework services are not available. " +
-        "Call bootstrapFramework(Services) before importing or defining components " +
-        "that use @PickRender. Missing service: 'IComponentMetadataRegistry'.",
+        "Call bootstrapFramework() on your service registry " +
+        "(e.g. bootstrapFramework(Services) in the default setup) " +
+        "before defining components that use @PickRender. Missing service: 'IComponentMetadataRegistry'.",
     );
   });
 
@@ -46,8 +47,9 @@ test.describe("Decorator bootstrap order", () => {
     // Act & Assert
     expect(defineComponent).toThrow(
       "[Pick] Framework services are not available. " +
-        "Call bootstrapFramework(Services) before importing or defining components " +
-        "that use @Pick. Missing service: 'IPickComponentFactory'.",
+        "Call bootstrapFramework() on your service registry " +
+        "(e.g. bootstrapFramework(Services) in the default setup) " +
+        "before defining components that use @Pick. Missing service: 'IPickComponentFactory'.",
     );
   });
 });

--- a/tests/unit/decorators/define-component.test.ts
+++ b/tests/unit/decorators/define-component.test.ts
@@ -107,4 +107,56 @@ test.describe("defineComponent", () => {
       ),
     ).toThrow("[defineComponent] config is required");
   });
+
+  test("should throw when config.selector is an empty string", () => {
+    // Arrange
+    class MyComponent {}
+
+    // Act & Assert
+    expect(() =>
+      defineComponent(
+        MyComponent as unknown as new (...args: unknown[]) => PickComponent,
+        { selector: "", template: "<p />" },
+      ),
+    ).toThrow("[defineComponent] config.selector is required and must not be empty");
+  });
+
+  test("should throw when config.selector is whitespace-only", () => {
+    // Arrange
+    class MyComponent {}
+
+    // Act & Assert
+    expect(() =>
+      defineComponent(
+        MyComponent as unknown as new (...args: unknown[]) => PickComponent,
+        { selector: "   ", template: "<p />" },
+      ),
+    ).toThrow("[defineComponent] config.selector is required and must not be empty");
+  });
+
+  test("should throw when config.selector has leading whitespace", () => {
+    // Arrange
+    class MyComponent {}
+
+    // Act & Assert
+    expect(() =>
+      defineComponent(
+        MyComponent as unknown as new (...args: unknown[]) => PickComponent,
+        { selector: " my-comp", template: "<p />" },
+      ),
+    ).toThrow("[defineComponent] config.selector must not have leading or trailing whitespace");
+  });
+
+  test("should throw when config.selector has trailing whitespace", () => {
+    // Arrange
+    class MyComponent {}
+
+    // Act & Assert
+    expect(() =>
+      defineComponent(
+        MyComponent as unknown as new (...args: unknown[]) => PickComponent,
+        { selector: "my-comp ", template: "<p />" },
+      ),
+    ).toThrow("[defineComponent] config.selector must not have leading or trailing whitespace");
+  });
 });

--- a/tests/unit/decorators/define-component.test.ts
+++ b/tests/unit/decorators/define-component.test.ts
@@ -1,0 +1,110 @@
+import { test, expect } from "@playwright/test";
+import { defineComponent } from "../../../src/decorators/define-component.js";
+import type { ComponentDefinition } from "../../../src/providers/framework-bootstrap.js";
+import type { PickComponent } from "../../../src/core/pick-component.js";
+
+/**
+ * Tests for defineComponent responsibility.
+ *
+ * Covers:
+ * - Returns a ComponentDefinition descriptor with kind "render"
+ * - Captures Class and config without side effects
+ * - Guard clause validation (Class required, config required)
+ */
+test.describe("defineComponent", () => {
+  test("should return a render descriptor when Class and config are provided", () => {
+    // Arrange
+    class MyComponent {}
+    const config = { selector: "my-comp", template: "<p>Hello</p>" };
+
+    // Act
+    const result = defineComponent(
+      MyComponent as unknown as new (...args: unknown[]) => PickComponent,
+      config,
+    );
+
+    // Assert
+    expect(result.kind).toBe("render");
+    const renderDef = result as Extract<ComponentDefinition, { kind: "render" }>;
+    expect(renderDef.Class).toBe(MyComponent);
+    expect(renderDef.config).toBe(config);
+  });
+
+  test("should preserve config reference without cloning", () => {
+    // Arrange
+    class AnotherComponent {}
+    const config = { selector: "another-comp", template: "<span>Hi</span>" };
+
+    // Act
+    const result = defineComponent(
+      AnotherComponent as unknown as new (...args: unknown[]) => PickComponent,
+      config,
+    );
+
+    // Assert
+    const renderDef = result as Extract<ComponentDefinition, { kind: "render" }>;
+    expect(renderDef.config).toBe(config);
+  });
+
+  test("should not register any service when called without bootstrapFramework", () => {
+    // Arrange
+    class IsolatedComponent {}
+    const config = { selector: "isolated-comp", template: "<div />" };
+
+    // Act — no bootstrap, should not throw
+    const result = defineComponent(
+      IsolatedComponent as unknown as new (...args: unknown[]) => PickComponent,
+      config,
+    );
+
+    // Assert — just a descriptor, no side effects
+    expect(result).toBeDefined();
+    expect(result.kind).toBe("render");
+  });
+
+  test("should throw when Class is null", () => {
+    // Arrange
+    const config = { selector: "my-comp", template: "<p />" };
+
+    // Act & Assert
+    expect(() =>
+      defineComponent(null as any, config),
+    ).toThrow("[defineComponent] Class is required");
+  });
+
+  test("should throw when Class is undefined", () => {
+    // Arrange
+    const config = { selector: "my-comp", template: "<p />" };
+
+    // Act & Assert
+    expect(() =>
+      defineComponent(undefined as any, config),
+    ).toThrow("[defineComponent] Class is required");
+  });
+
+  test("should throw when config is null", () => {
+    // Arrange
+    class MyComponent {}
+
+    // Act & Assert
+    expect(() =>
+      defineComponent(
+        MyComponent as unknown as new (...args: unknown[]) => PickComponent,
+        null as any,
+      ),
+    ).toThrow("[defineComponent] config is required");
+  });
+
+  test("should throw when config is undefined", () => {
+    // Arrange
+    class MyComponent {}
+
+    // Act & Assert
+    expect(() =>
+      defineComponent(
+        MyComponent as unknown as new (...args: unknown[]) => PickComponent,
+        undefined as any,
+      ),
+    ).toThrow("[defineComponent] config is required");
+  });
+});

--- a/tests/unit/decorators/define-pick.test.ts
+++ b/tests/unit/decorators/define-pick.test.ts
@@ -95,4 +95,34 @@ test.describe("definePick", () => {
       definePick("my-comp", undefined as any),
     ).toThrow("[definePick] setup is required");
   });
+
+  test("should throw when selector is whitespace-only", () => {
+    // Arrange
+    const setup = (_ctx: any) => {};
+
+    // Act & Assert
+    expect(() =>
+      definePick("   ", setup),
+    ).toThrow("[definePick] selector is required and must not be empty");
+  });
+
+  test("should throw when selector has leading whitespace", () => {
+    // Arrange
+    const setup = (_ctx: any) => {};
+
+    // Act & Assert
+    expect(() =>
+      definePick(" my-comp", setup),
+    ).toThrow("[definePick] selector must not have leading or trailing whitespace");
+  });
+
+  test("should throw when selector has trailing whitespace", () => {
+    // Arrange
+    const setup = (_ctx: any) => {};
+
+    // Act & Assert
+    expect(() =>
+      definePick("my-comp ", setup),
+    ).toThrow("[definePick] selector must not have leading or trailing whitespace");
+  });
 });

--- a/tests/unit/decorators/define-pick.test.ts
+++ b/tests/unit/decorators/define-pick.test.ts
@@ -1,0 +1,98 @@
+import { test, expect } from "@playwright/test";
+import { definePick } from "../../../src/decorators/define-pick.js";
+import type { ComponentDefinition } from "../../../src/providers/framework-bootstrap.js";
+
+/**
+ * Tests for definePick responsibility.
+ *
+ * Covers:
+ * - Returns a ComponentDefinition descriptor with kind "pick"
+ * - Captures selector and setup without side effects
+ * - Guard clause validation (selector required, setup required)
+ */
+test.describe("definePick", () => {
+  test("should return a pick descriptor when selector and setup are provided", () => {
+    // Arrange
+    const selector = "my-counter";
+    const setup = (ctx: any) => { ctx.html("<p>0</p>"); };
+
+    // Act
+    const result = definePick(selector, setup);
+
+    // Assert
+    expect(result.kind).toBe("pick");
+    const pickDef = result as Extract<ComponentDefinition, { kind: "pick" }>;
+    expect(pickDef.selector).toBe(selector);
+    expect(pickDef.setup).toBe(setup);
+  });
+
+  test("should preserve setup function reference without cloning", () => {
+    // Arrange
+    const selector = "my-form";
+    const setup = (ctx: any) => { ctx.html("<form />"); };
+
+    // Act
+    const result = definePick(selector, setup);
+
+    // Assert
+    const pickDef = result as Extract<ComponentDefinition, { kind: "pick" }>;
+    expect(pickDef.setup).toBe(setup);
+  });
+
+  test("should not register any service when called without bootstrapFramework", () => {
+    // Arrange
+    const selector = "isolated-pick";
+    const setup = (ctx: any) => { ctx.html("<div />"); };
+
+    // Act — no bootstrap, should not throw
+    const result = definePick(selector, setup);
+
+    // Assert — just a descriptor, no side effects
+    expect(result).toBeDefined();
+    expect(result.kind).toBe("pick");
+  });
+
+  test("should throw when selector is empty string", () => {
+    // Arrange
+    const setup = (_ctx: any) => {};
+
+    // Act & Assert
+    expect(() =>
+      definePick("", setup),
+    ).toThrow("[definePick] selector is required");
+  });
+
+  test("should throw when selector is null", () => {
+    // Arrange
+    const setup = (_ctx: any) => {};
+
+    // Act & Assert
+    expect(() =>
+      definePick(null as any, setup),
+    ).toThrow("[definePick] selector is required");
+  });
+
+  test("should throw when selector is undefined", () => {
+    // Arrange
+    const setup = (_ctx: any) => {};
+
+    // Act & Assert
+    expect(() =>
+      definePick(undefined as any, setup),
+    ).toThrow("[definePick] selector is required");
+  });
+
+  test("should throw when setup is null", () => {
+    // Act & Assert
+    expect(() =>
+      definePick("my-comp", null as any),
+    ).toThrow("[definePick] setup is required");
+  });
+
+  test("should throw when setup is undefined", () => {
+    // Act & Assert
+    expect(() =>
+      definePick("my-comp", undefined as any),
+    ).toThrow("[definePick] setup is required");
+  });
+});

--- a/tests/unit/decorators/define-pick.test.ts
+++ b/tests/unit/decorators/define-pick.test.ts
@@ -59,7 +59,7 @@ test.describe("definePick", () => {
     // Act & Assert
     expect(() =>
       definePick("", setup),
-    ).toThrow("[definePick] selector is required");
+    ).toThrow("[definePick] selector is required and must not be empty");
   });
 
   test("should throw when selector is null", () => {
@@ -69,7 +69,7 @@ test.describe("definePick", () => {
     // Act & Assert
     expect(() =>
       definePick(null as any, setup),
-    ).toThrow("[definePick] selector is required");
+    ).toThrow("[definePick] selector is required and must not be empty");
   });
 
   test("should throw when selector is undefined", () => {
@@ -79,7 +79,7 @@ test.describe("definePick", () => {
     // Act & Assert
     expect(() =>
       definePick(undefined as any, setup),
-    ).toThrow("[definePick] selector is required");
+    ).toThrow("[definePick] selector is required and must not be empty");
   });
 
   test("should throw when setup is null", () => {

--- a/tests/unit/playground/prerender-examples.test.ts-snapshots/prerender-es-01-hello-unit-linux.html
+++ b/tests/unit/playground/prerender-examples.test.ts-snapshots/prerender-es-01-hello-unit-linux.html
@@ -703,6 +703,10 @@
                   <a href="/es/13-dashboard">Dashboard</a>
                 </li><li>
                   <a href="/es/14-pick">@Pick Avanzado</a>
+                </li><li>
+                  <a href="/es/17-define-component">defineComponent</a>
+                </li><li>
+                  <a href="/es/18-define-pick">definePick</a>
                 </li>
           </ul>
         </section>

--- a/tests/unit/providers/framework-bootstrap.test.ts
+++ b/tests/unit/providers/framework-bootstrap.test.ts
@@ -669,4 +669,24 @@ test.describe("bootstrapFramework", () => {
       bootstrapFramework(mock as any, {}, { components: {} as any }),
     ).rejects.toThrow("[bootstrapFramework] options.components must be an array.");
   });
+
+  test("should throw when a components entry is null", async () => {
+    // Arrange
+    const mock = createMockServiceRegistry();
+
+    // Act & Assert
+    await expect(
+      bootstrapFramework(mock as any, {}, { components: [null as any] }),
+    ).rejects.toThrow("[bootstrapFramework] components[0]: each entry must be a non-null object produced by defineComponent() or definePick().");
+  });
+
+  test("should throw when a components entry is undefined", async () => {
+    // Arrange
+    const mock = createMockServiceRegistry();
+
+    // Act & Assert
+    await expect(
+      bootstrapFramework(mock as any, {}, { components: [undefined as any] }),
+    ).rejects.toThrow("[bootstrapFramework] components[0]: each entry must be a non-null object produced by defineComponent() or definePick().");
+  });
 });

--- a/tests/unit/providers/framework-bootstrap.test.ts
+++ b/tests/unit/providers/framework-bootstrap.test.ts
@@ -659,4 +659,14 @@ test.describe("bootstrapFramework", () => {
       bootstrapFramework(mock as any, {}, {}),
     ).resolves.toBeUndefined();
   });
+
+  test("should throw when options.components is not an array", async () => {
+    // Arrange
+    const mock = createMockServiceRegistry();
+
+    // Act & Assert
+    await expect(
+      bootstrapFramework(mock as any, {}, { components: {} as any }),
+    ).rejects.toThrow("[bootstrapFramework] options.components must be an array.");
+  });
 });

--- a/tests/unit/providers/framework-bootstrap.test.ts
+++ b/tests/unit/providers/framework-bootstrap.test.ts
@@ -639,4 +639,24 @@ test.describe("bootstrapFramework", () => {
       "<div>Default dialog</div>",
     );
   });
+
+  test("should succeed when components option is an empty array", async () => {
+    // Arrange
+    const mock = createMockServiceRegistry();
+
+    // Act & Assert — no error when components is empty
+    await expect(
+      bootstrapFramework(mock as any, {}, { components: [] }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("should succeed when components option is undefined", async () => {
+    // Arrange
+    const mock = createMockServiceRegistry();
+
+    // Act & Assert — no error when components is absent
+    await expect(
+      bootstrapFramework(mock as any, {}, {}),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/tests/unit/providers/framework-bootstrap.test.ts
+++ b/tests/unit/providers/framework-bootstrap.test.ts
@@ -689,4 +689,16 @@ test.describe("bootstrapFramework", () => {
       bootstrapFramework(mock as any, {}, { components: [undefined as any] }),
     ).rejects.toThrow("[bootstrapFramework] components[0]: each entry must be a non-null object produced by defineComponent() or definePick().");
   });
+
+  test("should throw when components array contains duplicate selectors", async () => {
+    // Arrange
+    const mock = createMockServiceRegistry();
+    const def1 = { kind: "pick" as const, selector: "dupe-selector", setup: (_ctx: any) => {} };
+    const def2 = { kind: "pick" as const, selector: "dupe-selector", setup: (_ctx: any) => {} };
+
+    // Act & Assert
+    await expect(
+      bootstrapFramework(mock as any, {}, { components: [def1, def2] as any }),
+    ).rejects.toThrow("[bootstrapFramework] components[1]: duplicate selector 'dupe-selector' — already present earlier in this components array.");
+  });
 });


### PR DESCRIPTION
- defineComponent: descriptor-based alternative to @PickRender
- definePick: decorator-free alternative to @Pick (no class needed)
- bootstrapFramework: new \`components\` option for explicit composition root
- ComponentDefinition: exported discriminated union type
- ComponentKind: internal enum used by the registration dispatch loop
- Playground examples 17 (defineComponent) and 18 (definePick), 4 locale variants each
- Docs: 'Using without decorators' section in PICK-VS-PICKRENDER (EN + ES)
- Tests: unit tests for descriptor factories, integration tests including end-to-end coverage via defineComponent/definePick → bootstrapFramework
- Fix: beforeEach/afterEach customElements isolation in integration tests