### PR TITLE
fix(ci): add tag input to workflow_dispatch and checkout correct ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,18 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v1.0.7)"
+        required: true
+        type: string
 
 permissions:
   contents: write
   id-token: write
+
+env:
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
 
 jobs:
   verify-node:
@@ -18,6 +26,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -29,13 +39,15 @@ jobs:
       - name: Verify tag matches package version
         shell: bash
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG_VERSION="${RELEASE_TAG#v}"
           PACKAGE_VERSION="$(npm pkg get version | tr -d '"')"
 
           if [[ "$TAG_VERSION" != "$PACKAGE_VERSION" ]]; then
             echo "Tag version ($TAG_VERSION) does not match package.json version ($PACKAGE_VERSION)."
             exit 1
           fi
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
 
       - name: Install dependencies
         run: npm ci
@@ -63,6 +75,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -98,6 +112,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -109,13 +125,15 @@ jobs:
       - name: Verify tag matches package version
         shell: bash
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG_VERSION="${RELEASE_TAG#v}"
           PACKAGE_VERSION="$(npm pkg get version | tr -d '"')"
 
           if [[ "$TAG_VERSION" != "$PACKAGE_VERSION" ]]; then
             echo "Tag version ($TAG_VERSION) does not match package.json version ($PACKAGE_VERSION)."
             exit 1
           fi
+        env:
+          RELEASE_TAG: ${{ env.RELEASE_TAG }}
 
       - name: Install dependencies
         run: npm ci
@@ -142,16 +160,17 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           generate_release_notes: true
           files: |
-            .release-artifacts/${{ github.ref_name }}/pick-components.js
-            .release-artifacts/${{ github.ref_name }}/pick-components.js.map
-            .release-artifacts/${{ github.ref_name }}/pick-components.min.js
-            .release-artifacts/${{ github.ref_name }}/pick-components.min.js.map
-            .release-artifacts/${{ github.ref_name }}/pick-components-bootstrap.js
-            .release-artifacts/${{ github.ref_name }}/pick-components-bootstrap.js.map
-            .release-artifacts/${{ github.ref_name }}/pick-components-bootstrap.min.js
-            .release-artifacts/${{ github.ref_name }}/pick-components-bootstrap.min.js.map
-            .release-artifacts/${{ github.ref_name }}/SHA256SUMS
-            .release-artifacts/${{ github.ref_name }}/README.txt
-            .release-artifacts/${{ github.ref_name }}/LICENSE
+            .release-artifacts/${{ env.RELEASE_TAG }}/pick-components.js
+            .release-artifacts/${{ env.RELEASE_TAG }}/pick-components.js.map
+            .release-artifacts/${{ env.RELEASE_TAG }}/pick-components.min.js
+            .release-artifacts/${{ env.RELEASE_TAG }}/pick-components.min.js.map
+            .release-artifacts/${{ env.RELEASE_TAG }}/pick-components-bootstrap.js
+            .release-artifacts/${{ env.RELEASE_TAG }}/pick-components-bootstrap.js.map
+            .release-artifacts/${{ env.RELEASE_TAG }}/pick-components-bootstrap.min.js
+            .release-artifacts/${{ env.RELEASE_TAG }}/pick-components-bootstrap.min.js.map
+            .release-artifacts/${{ env.RELEASE_TAG }}/SHA256SUMS
+            .release-artifacts/${{ env.RELEASE_TAG }}/README.txt
+            .release-artifacts/${{ env.RELEASE_TAG }}/LICENSE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
   id-token: write
 
 env:
-  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+  RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
 
 jobs:
   verify-node:


### PR DESCRIPTION
When release.yml is triggered via workflow_dispatch the GITHUB_REF_NAME is the branch ('main'), not a tag. Add a required 'tag' input (e.g. v1.0.7), compute RELEASE_TAG env var once at workflow level, and use it in all jobs for: checkout ref, version verification, artifact paths, and GitHub Release tag_name.