### PR TITLE
Fix/define pick pick action syntax

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Type `/setup-pick-components` in Copilot chat to set up your project with pre-co
 - Implementing factory-first dependency injection
 - Writing secure templates
 
-**First time with Pick Components?** See [SETUP.md](#) or visit the [live playground](https://pick-components.github.io/pick-components/).
+**First time with Pick Components?** See [docs/GETTING-STARTED.md](../docs/GETTING-STARTED.md) or visit the [live playground](https://pick-components.github.io/pick-components/).
 
 ## Code Style
 

--- a/.github/skills/setup-pick-components/01-create-components.md
+++ b/.github/skills/setup-pick-components/01-create-components.md
@@ -65,8 +65,10 @@ Register at bootstrap:
 
 ```typescript
 // bootstrap.ts
-import "./my-counter.js"; // side-effect import triggers decorator registration
+import { bootstrapFramework, Services } from "pick-components/bootstrap";
+
 await bootstrapFramework(Services);
+await import("./my-counter.js"); // dynamic import: decorator side effects run after services are registered
 ```
 
 ---

--- a/.github/skills/setup-pick-components/01-create-components.md
+++ b/.github/skills/setup-pick-components/01-create-components.md
@@ -2,6 +2,185 @@
 
 Use this prompt when you need Copilot to generate Pick Components with proper architecture.
 
+## Component APIs — Choose the Right One
+
+Pick Components has **four APIs** depending on how much decorator/class syntax you want:
+
+| API | When to use |
+|-----|-------------|
+| `@PickRender` | Full-featured with decorator: initializer, lifecycle, skeleton, errorTemplate |
+| `defineComponent` | Decorator-free alternative to `@PickRender`; class uses `@Reactive`/`@Listen`, registration via `bootstrapFramework` |
+| `@Pick` | Inline context (decorator, but setup via `ctx.*`) |
+| `definePick` | Fully decorator-free, functional — no class, no `@Reactive`, no `@Listen` |
+
+### `pick-action` — ALWAYS a custom element
+
+**`<pick-action>` is a custom element, not an HTML attribute.** It wraps the interactive element:
+
+```html
+<!-- ✅ CORRECT — pick-action wraps the button -->
+<pick-action action="increment"><button type="button">+</button></pick-action>
+
+<!-- ❌ WRONG — pick-action="..." as an attribute does nothing -->
+<button pick-action="increment" type="button">+</button>
+```
+
+This applies equally to `@PickRender`, `@Pick`, and `definePick` components.
+
+---
+
+## `@Pick` — Inline context with decorator
+
+Use when you want decorator syntax but prefer configuring via `ctx.*` instead of class fields:
+
+```typescript
+import { Pick, PickComponent } from "pick-components";
+import counterStyles from "./counter.styles.css";
+
+@Pick<{ count: number }>("my-counter", (ctx) => {
+  ctx.state({ count: 0 });
+
+  // ctx.on defines the view-action map for <pick-action action="...">
+  ctx.on({
+    increment() { this.count++; },
+    decrement() { this.count--; },
+    reset() { this.count = 0; },
+  });
+
+  ctx.css(counterStyles);
+
+  ctx.html(`
+    <div class="counter">
+      <p>{{count}}</p>
+      <pick-action action="decrement"><button type="button">−</button></pick-action>
+      <pick-action action="reset"><button type="button">Reset</button></pick-action>
+      <pick-action action="increment"><button type="button">+</button></pick-action>
+    </div>
+  `);
+})
+export class MyCounter extends PickComponent {}
+```
+
+Register at bootstrap:
+
+```typescript
+// bootstrap.ts
+import "./my-counter.js"; // side-effect import triggers decorator registration
+await bootstrapFramework(Services);
+```
+
+---
+
+## `definePick` — Decorator-free functional API
+
+Use when decorators are unavailable or you want fully explicit registration:
+
+```typescript
+import { definePick } from "pick-components";
+import counterStyles from "./counter.styles.css";
+
+export const counterDef = definePick<{ count: number }>("my-counter", (ctx) => {
+  ctx.state({ count: 0 });
+
+  // ctx.on defines the view-action map for <pick-action action="...">
+  ctx.on({
+    increment() { this.count++; },
+    decrement() { this.count--; },
+    reset() { this.count = 0; },
+  });
+
+  ctx.css(counterStyles);
+
+  ctx.html(`
+    <div class="counter">
+      <p>{{count}}</p>
+      <pick-action action="decrement"><button type="button">−</button></pick-action>
+      <pick-action action="reset"><button type="button">Reset</button></pick-action>
+      <pick-action action="increment"><button type="button">+</button></pick-action>
+    </div>
+  `);
+});
+```
+
+Register explicitly at bootstrap — no side effects until `bootstrapFramework` runs:
+
+```typescript
+// bootstrap.ts
+import { counterDef } from "./my-counter.js";
+await bootstrapFramework(Services, {}, { components: [counterDef] });
+```
+
+> For the full `ctx.*` API (ctx.listen, ctx.computed, ctx.intent, ctx.lifecycle, ctx.initializer, etc.) see [05-inline-context-api.md](./05-inline-context-api.md).
+
+---
+
+## `defineComponent` — Decorator-free alternative to `@PickRender`
+
+Use when decorators are unavailable **but you still want a class** with `@Reactive` and `@Listen`. The class itself is written identically to a `@PickRender` component; only the registration moves to `bootstrapFramework`:
+
+```typescript
+import { PickComponent, Reactive, Listen, defineComponent } from "pick-components";
+import counterStyles from "./counter.styles.css";
+
+// Class written as normal — @Reactive and @Listen are still used here
+class CounterExample extends PickComponent {
+  @Reactive count = 0;
+
+  @Listen("#decrementButton", "click")
+  decrement(): void { this.count--; }
+
+  @Listen("#resetButton", "click")
+  reset(): void { this.count = 0; }
+
+  @Listen("#incrementButton", "click")
+  increment(): void { this.count++; }
+}
+
+// defineComponent replaces @PickRender — returns a ComponentDefinition descriptor
+export const counterDef = defineComponent(CounterExample, {
+  selector: "counter-example",
+  styles: counterStyles,
+  template: `
+    <div class="counter">
+      <p>{{count}}</p>
+      <div class="actions">
+        <button id="decrementButton" type="button">−</button>
+        <button id="resetButton" type="button">Reset</button>
+        <button id="incrementButton" type="button">+</button>
+      </div>
+    </div>
+  `,
+});
+```
+
+Register explicitly at bootstrap:
+
+```typescript
+// bootstrap.ts
+import { counterDef } from "./counter.example.js";
+await bootstrapFramework(Services, {}, { components: [counterDef] });
+```
+
+> **Note:** Unlike `definePick`, `defineComponent` still uses `@Reactive` and `@Listen` on the class body. It does NOT use `ctx.on()`.
+
+`defineComponent` accepts the same config options as `@PickRender` — you can pass `initializer`, `lifecycle`, `skeleton`, and `errorTemplate` alongside `selector`, `template`, and `styles`:
+
+```typescript
+export const myDef = defineComponent(MyComponent, {
+  selector: "my-component",
+  template,
+  styles,
+  initializer: () => Services.getNew(MyComponentInitializer),
+  lifecycle:    () => Services.getNew(MyComponentLifecycle),
+  skeleton:     '<p aria-busy="true">Loading…</p>',
+  errorTemplate: '<p role="alert">Failed to load.</p>',
+});
+```
+
+---
+
+## `@PickRender` — Full-featured with initializer/lifecycle
+
 ## Component Structure
 
 Pick Components use `@PickRender` decorator with `initializer` and `lifecycle`:
@@ -117,6 +296,41 @@ export class MyComponentLifecycle extends PickLifecycleManager<MyComponent> {
 </div>
 ```
 
+### `pick-action` in `@PickRender` / `defineComponent` — two patterns
+
+**Pattern A — via intent + lifecycle** (preferred when the action triggers async logic or service calls):
+
+The template uses `<pick-action action="requestAction">` → the component method fires `actionRequested$.notify()` → the lifecycle reacts and calls the service.
+
+**Pattern B — via `getViewActions()`** (simpler for pure UI actions with no service interaction):
+
+```typescript
+import { PickViewActions } from "pick-components";
+
+export class MyComponent extends PickComponent {
+  @Reactive count = 0;
+
+  // getViewActions() maps pick-action names to handlers.
+  // `this` is the component instance.
+  getViewActions(): PickViewActions {
+    return {
+      increment: () => { this.count++; },
+      decrement: () => { this.count--; },
+      reset:     () => { this.count = 0; },
+    };
+  }
+}
+```
+
+```html
+<!-- Template -->
+<pick-action action="increment"><button type="button">+</button></pick-action>
+<pick-action action="decrement"><button type="button">−</button></pick-action>
+<pick-action action="reset"><button type="button">Reset</button></pick-action>
+```
+
+> Use Pattern A when the action needs a service. Use Pattern B for simple local state mutations.
+
 ### Composition Root Registration
 
 Initializers and lifecycles must be registered with factory functions so `Services.getNew()` creates a fresh instance each time:
@@ -145,6 +359,7 @@ Services.register(
 ❌ Skip `initializer` — Always hydrate data upfront  
 ❌ Mix business logic in components — Use lifecycle binding  
 ❌ Template logic beyond expressions — Validate in services  
+❌ Use `pick-action` as an HTML attribute — It is a **custom element**, always wrap: `<pick-action action="name"><button>...</button></pick-action>`  
 
 ## Real Example from Kronometa
 

--- a/.github/skills/setup-pick-components/05-inline-context-api.md
+++ b/.github/skills/setup-pick-components/05-inline-context-api.md
@@ -1,0 +1,290 @@
+# InlineContext API — `@Pick` and `definePick`
+
+Both `@Pick` and `definePick` receive the same `InlineContext` object as their setup argument. This reference covers every `ctx.*` method with real examples.
+
+## Quick reference
+
+| Method | Purpose | Equivalent in `@PickRender` |
+|--------|---------|---------------------------|
+| `ctx.state()` | Declare reactive state | `@Reactive` fields |
+| `ctx.on()` | Map `pick-action` names to handlers | `getViewActions()` |
+| `ctx.listen()` | Native DOM event delegation | `@Listen` decorator |
+| `ctx.computed()` | Derived (cached) state properties | Getter + `@Reactive` |
+| `ctx.intent()` | Declare an intent signal property | `this.createIntent()` |
+| `ctx.initializer()` | Async data loading on mount | `PickInitializer` class |
+| `ctx.lifecycle()` | Subscriptions + cleanup | `PickLifecycleManager` class |
+| `ctx.html()` | Component template string | `template` config |
+| `ctx.css()` | Scoped CSS string | `styles` config |
+| `ctx.skeleton()` | Loading placeholder template | `skeleton` config |
+| `ctx.errorTemplate()` | Error fallback template | `errorTemplate` config |
+| `ctx.props()` | Type-annotate observed attributes | `@PickRender` props config |
+| `ctx.ref()` | Register a template element reference | n/a |
+| `ctx.rules()` | Business validation config spread via `[[Rules.*]]` | n/a |
+
+---
+
+## `ctx.state(initial)` — reactive state
+
+Declares the reactive state object. Each field becomes a reactive property bound to `{{mustache}}` expressions in the template.
+
+```typescript
+ctx.state({ count: 0, label: "default" });
+```
+
+---
+
+## `ctx.on(handlers)` — pick-action map
+
+Maps action names to handler functions. Each handler is called with `this` bound to the component state. Connect actions in the template using `<pick-action action="name">`.
+
+```typescript
+ctx.on({
+  increment() { this.count++; },
+  decrement() { this.count--; },
+  reset()     { this.count = 0; },
+  select(value) { this.selected = value as string; },  // value comes from pick-action value="..."
+});
+```
+
+```html
+<!-- Template: pick-action is a CUSTOM ELEMENT, not an attribute -->
+<pick-action action="increment"><button type="button">+</button></pick-action>
+<pick-action action="select" value="option-a"><button type="button">A</button></pick-action>
+```
+
+---
+
+## `ctx.listen(selector?, eventName, handler)` — native DOM events
+
+For native DOM events (input, change, submit, keydown, etc.) that `pick-action` doesn't cover. `this` inside the handler is the component state.
+
+```typescript
+// Delegated — fires when element matching selector emits the event
+ctx.listen("#searchInput", "input", function (event) {
+  this.query = (event.target as HTMLInputElement).value;
+});
+
+ctx.listen("form#noteForm", "submit", function (event) {
+  event.preventDefault();
+  this.notes.push(this.draft);
+  this.draft = "";
+});
+
+// Root listener — fires on any event reaching the component root
+ctx.listen("keydown", function (event) {
+  if ((event as KeyboardEvent).key === "Escape") this.open = false;
+});
+```
+
+> **Rule:** Use `ctx.on` for intent-driven user actions (buttons, picks). Use `ctx.listen` for native value-change events (inputs, forms, keyboard).
+
+---
+
+## `ctx.computed(definitions)` — derived state
+
+Defines getter functions whose return values are cached and re-evaluated when accessed state changes. Use `this` to read from reactive state.
+
+```typescript
+ctx.state({ firstName: "Ada", lastName: "Lovelace", progress: 68 });
+
+ctx.computed({
+  fullName()      { return `${this.firstName} ${this.lastName}`.trim(); },
+  initials()      { return `${this.firstName[0] ?? ""}${this.lastName[0] ?? ""}`.toUpperCase(); },
+  progressLabel() { return `${Math.min(Math.max(this.progress, 0), 100)}%`; },
+  status()        { return this.progress >= 80 ? "Ready" : "In progress"; },
+});
+```
+
+Computed properties are available in templates like normal state: `{{fullName}}`, `{{status}}`.
+
+---
+
+## `ctx.intent(name)` — intent signals
+
+Declares a per-instance `IIntentSignal` property on the component. Used to signal external intent from an action to the lifecycle (pub/sub decoupling).
+
+```typescript
+import type { IIntentSignal } from "pick-components";
+
+// Declare the type shape for the component+state combined
+type CatalogComponent = PickComponent & CatalogState & {
+  refreshRequested$: IIntentSignal;
+};
+
+ctx.intent("refreshRequested$");
+
+ctx.on({
+  refresh() {
+    // `this` is the component — cast to access the intent
+    (this as CatalogComponent).refreshRequested$.notify();
+  },
+});
+```
+
+Subscribe in `ctx.lifecycle`:
+
+```typescript
+ctx.lifecycle({
+  onInit(component, subs) {
+    const host = component as CatalogComponent;
+    subs.addSubscription(
+      host.refreshRequested$.subscribe(() => service.refresh()),
+    );
+  },
+});
+```
+
+---
+
+## `ctx.initializer(fn, createDeps?)` — async data loading
+
+Runs once on mount before the component renders. Use it to load initial data. Optionally accepts a `createDeps` factory to inject services.
+
+```typescript
+ctx.initializer(
+  async function (component, deps) {
+    component.products = await deps!.catalog.loadCatalog();
+  },
+  () => ({ catalog: Services.get<CatalogService>("CatalogService") }),
+);
+```
+
+> **Note:** `createDeps` is called fresh each time the component mounts. Never capture services outside the factory — that would create hidden singletons.
+
+---
+
+## `ctx.lifecycle(hooks, createDeps?)` — subscriptions and cleanup
+
+Subscribe to signals or service observables on mount; unsubscribe on unmount. `subs.addSubscription(unsubscribe)` registers cleanup automatically.
+
+```typescript
+ctx.lifecycle(
+  {
+    onInit(component, subs, deps) {
+      const catalog = deps!.catalog;
+      catalog.startStockUpdates();
+
+      subs.addSubscription(
+        catalog.onStockChange((updated) => {
+          component.products = updated;
+        }),
+      );
+    },
+    onDestroy(_component, _subs, deps) {
+      deps!.catalog.stopStockUpdates();
+    },
+  },
+  () => ({ catalog: Services.get<CatalogService>("CatalogService") }),
+);
+```
+
+---
+
+## `ctx.html(template)` — component template
+
+Sets the HTML template string. Supports `{{reactive}}`, `[[CONSTANT]]`, `<pick-action>`, `<pick-select>`, `<pick-for>`, and `<slot>`. See [04-template-safety.md](./04-template-safety.md) for full template syntax.
+
+```typescript
+ctx.html(`
+  <div class="panel">
+    <p>{{fullName}}</p>
+    <pick-action action="reset"><button type="button">Reset</button></pick-action>
+  </div>
+`);
+```
+
+---
+
+## `ctx.css(styles)` — scoped styles
+
+Sets scoped CSS for the component. Usually imported from a `.css` file:
+
+```typescript
+import myStyles from "./my-component.styles.css";
+ctx.css(myStyles);
+```
+
+---
+
+## `ctx.skeleton(template)` and `ctx.errorTemplate(template)`
+
+Define loading and error placeholder HTML shown while `ctx.initializer` is running or if it throws:
+
+```typescript
+ctx.skeleton('<p aria-busy="true">Loading catalog…</p>');
+ctx.errorTemplate('<p role="alert">Failed to load catalog.</p>');
+```
+
+---
+
+## Complete example — `@Pick` with all ctx methods
+
+```typescript
+import { Pick, Services } from "pick-components";
+import type { IIntentSignal, InlineContext, PickComponent } from "pick-components";
+import myStyles from "./my-component.styles.css";
+
+interface MyState {
+  query: string;
+  results: string[];
+  loading: boolean;
+}
+
+type MyComponent = PickComponent & MyState & { searchRequested$: IIntentSignal };
+
+@Pick<MyState>("my-search", (ctx: InlineContext<MyState>) => {
+  ctx.state({ query: "", results: [], loading: false });
+
+  ctx.intent("searchRequested$");
+
+  ctx.computed({
+    hasResults() { return this.results.length > 0; },
+    placeholder() { return this.loading ? "Searching…" : "No results"; },
+  });
+
+  ctx.on({
+    search() { (this as MyComponent).searchRequested$.notify(); },
+    clear()  { this.query = ""; this.results = []; },
+  });
+
+  ctx.listen("#searchInput", "input", function (event) {
+    this.query = (event.target as HTMLInputElement).value;
+  });
+
+  ctx.initializer(
+    async function (component, deps) {
+      component.results = await deps!.svc.getDefaults();
+    },
+    () => ({ svc: Services.get("SearchService") }),
+  );
+
+  ctx.lifecycle(
+    {
+      onInit(component, subs, deps) {
+        const host = component as MyComponent;
+        subs.addSubscription(
+          host.searchRequested$.subscribe(async () => {
+            component.loading = true;
+            component.results = await deps!.svc.search(component.query);
+            component.loading = false;
+          }),
+        );
+      },
+    },
+    () => ({ svc: Services.get("SearchService") }),
+  );
+
+  ctx.skeleton('<p aria-busy="true">Loading…</p>');
+  ctx.errorTemplate('<p role="alert">Failed to load.</p>');
+  ctx.css(myStyles);
+  ctx.html(`
+    <div class="search">
+      <input id="searchInput" type="search" value="{{query}}" />
+      <pick-action action="search"><button type="button">Search</button></pick-action>
+      <pick-action action="clear"><button type="button">Clear</button></pick-action>
+      <p>{{hasResults ? results.length + ' results' : placeholder}}</p>
+    </div>
+  `);
+})
+export class MySearch {}
+```

--- a/.github/skills/setup-pick-components/SKILL.md
+++ b/.github/skills/setup-pick-components/SKILL.md
@@ -1,46 +1,59 @@
 ---
 name: pick-components-setup
-description: "Setup Copilot for a Pick Components project. Use when: creating or maintaining Pick Components code; generating components, tests, DI setup, and templates with real framework syntax. Covers zero-dependency Services registry, optional external DI integration, Playwright test projects, and safe template expressions."
+description: "Setup Copilot for a Pick Components project. Use when: creating or maintaining Pick Components code; generating components (@PickRender, @Pick, definePick, defineComponent), tests, DI setup, and templates with real framework syntax. Covers InlineContext ctx.* API (ctx.state, ctx.on, ctx.listen, ctx.computed, ctx.intent, ctx.lifecycle, ctx.initializer), zero-dependency Services registry, optional external DI integration, Playwright test projects, and safe template expressions."
 ---
 
 # Setup Pick Components Project
 
 Configures your project to work seamlessly with Pick Components and GitHub Copilot. This skill provides reusable guidance files under `.github/skills/setup-pick-components/`.
 
+## Component APIs — Choose the Right One
+
+| API | When to use |
+|-----|-------------|
+| `@PickRender` | Full-featured with decorator: initializer, lifecycle, skeleton, errorTemplate |
+| `defineComponent` | Decorator-free alternative to `@PickRender`; class uses `@Reactive`/`@Listen` |
+| `@Pick` | Inline context (decorator, setup via `ctx.*`) |
+| `definePick` | Fully decorator-free, functional — no class, no `@Reactive`, no `@Listen` |
+
+**`<pick-action>` is a custom element, not an HTML attribute.** Always wrap: `<pick-action action="name"><button>…</button></pick-action>`
+
 ## What This Skill Does
 
-1. ✅ Provides audited patterns for components, tests, DI, and templates
-2. ✅ Aligns generated code with Pick Components syntax and architecture
-3. ✅ Keeps DI guidance centered on built-in `Services` first
-4. ✅ Documents optional external DI integration when needed
+1. ✅ Documents all four component APIs with real examples
+2. ✅ Covers the full InlineContext (`ctx.*`) API for `@Pick` and `definePick`
+3. ✅ Aligns generated code with Pick Components syntax and architecture
+4. ✅ Keeps DI guidance centered on built-in `Services` first
+5. ✅ Documents optional external DI integration when needed
 
 ## Quick Start
 
 This skill will help you:
 
-### For Pick Components Components
-- Create `@Pick` and `@PickRender` decorated components
-- Structure JSDoc with proper `@param`, `@returns`, `@example`
-- Inject dependencies via factory functions
-- Keep logic in services, templates pure
+### For Component Creation
+- See [01-create-components.md](./01-create-components.md) — all four APIs with examples
+- See [05-inline-context-api.md](./05-inline-context-api.md) — full `ctx.*` reference for `@Pick`/`definePick` (ctx.state, ctx.on, ctx.listen, ctx.computed, ctx.intent, ctx.lifecycle, ctx.initializer, ctx.skeleton, ctx.errorTemplate, ctx.css, ctx.html, ctx.props, ctx.ref, ctx.rules)
 
 ### For Testing
 - Follow AAA pattern (Arrange-Act-Assert)
 - Write descriptive test names
 - Create unit and integration tests correctly
 - Handle error cases explicitly
+- See [02-writing-tests.md](./02-writing-tests.md)
 
 ### For Architecture
 - Use factory-first DI patterns
 - Separate business logic from presentation
 - Create proper service abstractions
 - Follow composition root patterns
+- See [03-dependency-injection.md](./03-dependency-injection.md)
 
 ### For Templates
 - Write secure template expressions
 - Use property bindings correctly
 - Handle actions and signals properly
 - Validate input in services, not templates
+- See [04-template-safety.md](./04-template-safety.md)
 
 ## Files Created
 
@@ -51,10 +64,11 @@ This skill includes:
 ├── skills/
 │   └── setup-pick-components/
 │       ├── SKILL.md
-│       ├── 01-create-components.md
+│       ├── 01-create-components.md       ← All 4 APIs with examples
 │       ├── 02-writing-tests.md
 │       ├── 03-dependency-injection.md
-│       └── 04-template-safety.md
+│       ├── 04-template-safety.md
+│       └── 05-inline-context-api.md      ← Full ctx.* API reference
 ```
 
 ## How to Use This Skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.8] - 2026-05-10
+
 ### Added
 - Added `docs/GETTING-STARTED.md` and `docs/GETTING-STARTED.es.md`: step-by-step guide (project → npm → Copilot skill → first component) covering all four component APIs (`@Pick`, `definePick`, `@PickRender`, `defineComponent`).
 - Added `.github/skills/setup-pick-components/05-inline-context-api.md`: complete `ctx.*` InlineContext API reference for `@Pick` and `definePick` (`ctx.state`, `ctx.on`, `ctx.listen`, `ctx.computed`, `ctx.intent`, `ctx.lifecycle`, `ctx.initializer`, `ctx.skeleton`, `ctx.errorTemplate`, `ctx.html`, `ctx.css`, `ctx.props`, `ctx.ref`, `ctx.rules`).
@@ -62,5 +64,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed stale references to old `janmbaco` GitHub repository and legacy playground URL in project metadata and guidance docs.
 - Fixed unit prerender expectations by updating `prerender-examples` snapshot and color-token assertions after branding/theme updates.
 
-[Unreleased]: https://github.com/pick-components/pick-components/compare/v1.0.7...HEAD
+[Unreleased]: https://github.com/pick-components/pick-components/compare/v1.0.8...HEAD
+[1.0.8]: https://github.com/pick-components/pick-components/compare/v1.0.7...v1.0.8
 [1.0.7]: https://github.com/pick-components/pick-components/compare/v1.0.6...v1.0.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `docs/GETTING-STARTED.md` and `docs/GETTING-STARTED.es.md`: step-by-step guide (project → npm → Copilot skill → first component) covering all four component APIs (`@Pick`, `definePick`, `@PickRender`, `defineComponent`).
+- Added `.github/skills/setup-pick-components/05-inline-context-api.md`: complete `ctx.*` InlineContext API reference for `@Pick` and `definePick` (`ctx.state`, `ctx.on`, `ctx.listen`, `ctx.computed`, `ctx.intent`, `ctx.lifecycle`, `ctx.initializer`, `ctx.skeleton`, `ctx.errorTemplate`, `ctx.html`, `ctx.css`, `ctx.props`, `ctx.ref`, `ctx.rules`).
+
+### Changed
+- Updated `.github/skills/setup-pick-components/SKILL.md` description with all four API names and `ctx.*` keywords for better Copilot skill discovery.
+- Updated `.github/skills/setup-pick-components/01-create-components.md` with a 4-API comparison table, `@Pick`, `definePick`, and `defineComponent` sections, `getViewActions()` patterns, and `pick-action` custom element warning.
+- Updated `docs/README.md` and `docs/README.es.md` with `GETTING-STARTED` entries.
+- Updated `README.md` Start Paths with a link to `GETTING-STARTED.md`.
+- Fixed broken `SETUP.md` link in `.github/copilot-instructions.md`.
+
 ### Fixed
+- Fixed `definePick` playground example (`18-define-pick`) where `pick-action` was used as an HTML attribute instead of a custom element wrapper; all four locale variants updated.
 - Moved brand SVG assets from `examples/.github/brand/` to `examples/brand/` so GitHub Pages serves them correctly (`.github/` paths are not exposed as HTTP routes by GitHub Pages).
 - Fixed `release.yml` workflow never triggering: `GITHUB_TOKEN`-based tag pushes do not trigger other workflows. Added `workflow_dispatch` to `release.yml` and a `gh workflow run` step in `tag-release.yml` that explicitly triggers the release after tag creation.
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ See the full setup guide in [docs/USAGE-GUIDE.md#copilot-ai-setup-optional](docs
 ## Start Paths
 
 - **I want to build now (npm + bundler):** stay in this README and use the Quickstart above.
+- **I want a step-by-step guide with Copilot:** see [docs/GETTING-STARTED.md](docs/GETTING-STARTED.md).
 - **I want no decorators:** see [docs/USAGE-GUIDE.md#using-without-decorators-definecomponent-and-definepick](docs/USAGE-GUIDE.md#using-without-decorators-definecomponent-and-definepick).
 - **I want Copilot setup:** see [docs/USAGE-GUIDE.md#copilot-ai-setup-optional](docs/USAGE-GUIDE.md#copilot-ai-setup-optional).
 - **I want plain browser ESM (no bundler):** see [docs/USAGE-GUIDE.md](docs/USAGE-GUIDE.md).

--- a/docs/GETTING-STARTED.es.md
+++ b/docs/GETTING-STARTED.es.md
@@ -1,0 +1,298 @@
+# Primeros Pasos con Pick Components
+
+Esta guía te lleva desde una carpeta vacía hasta tu primer componente en funcionamiento. Asume que tienes Node.js 18+ instalado.
+
+---
+
+## Paso 1 — Crea tu proyecto
+
+```bash
+mkdir mi-app && cd mi-app
+npm init -y
+npm install typescript --save-dev
+```
+
+Añade un `tsconfig.json` mínimo:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "moduleResolution": "bundler",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}
+```
+
+> Si tu bundler requiere un `moduleResolution` diferente, ajústalo según corresponda. Pick Components distribuye ESM estándar y funciona con Vite, Rollup, Webpack y esbuild.
+
+---
+
+## Paso 2 — Instala Pick Components
+
+```bash
+npm install pick-components
+```
+
+---
+
+## Paso 3 — Instala el skill de Copilot
+
+El skill de Copilot le enseña a GitHub Copilot las convenciones de Pick Components para que genere componentes, tests, configuración de DI y templates correctos, sin tener que adivinar.
+
+Instálalo en tu proyecto con:
+
+```bash
+npx --package=pick-components pick-components-copilot
+```
+
+Esto copia `.github/skills/setup-pick-components/` en la raíz de tu proyecto. Haz commit del resultado para que todo el equipo se beneficie.
+
+Si prefieres instalarlo manualmente, copia la carpeta `setup-pick-components/` desde el [repositorio](https://github.com/pick-components/pick-components/tree/main/.github/skills/setup-pick-components) en `.github/skills/` de tu proyecto.
+
+---
+
+## Paso 4 — Actívalo en el chat de Copilot
+
+Abre el chat de GitHub Copilot (VS Code o web) y escribe:
+
+```
+/setup-pick-components
+```
+
+Copilot carga el skill y a partir de ese momento genera código Pick Components siguiendo las convenciones del framework.
+
+---
+
+## Paso 5 — Genera tu proyecto con Copilot
+
+### 5a. Genera los archivos de entrada
+
+Pega este prompt en el chat de Copilot:
+
+> Crea un `index.html` y un `src/bootstrap.ts` mínimos para un proyecto Pick Components con npm y un bundler.
+
+Copilot producirá:
+
+**`index.html`**
+```html
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mi App</title>
+    <script type="module" src="./src/main.js"></script>
+  </head>
+  <body>
+    <!-- tus componentes van aquí -->
+  </body>
+</html>
+```
+
+**`src/bootstrap.ts`**
+```typescript
+import { bootstrapFramework, Services } from "pick-components/bootstrap";
+
+await bootstrapFramework(Services);
+```
+
+> `bootstrapFramework` debe completarse antes de que se importe cualquier módulo de componentes. Usa `await` de nivel superior (ESM) para garantizar el orden.
+
+### 5b. Crea tu primer componente
+
+Elige el estilo que prefieras y pega el prompt correspondiente en el chat de Copilot.
+
+> **Consejo:** dile a Copilot dónde debe ir el componente en la página para que también actualice el `index.html` por ti. Si es el único componente de la página, di «como contenido principal de la página». Si va dentro de una sección concreta, descríbela — p. ej. «dentro de un `<main>` debajo de un `<header>`».
+
+#### Contexto inline — `@Pick` (con decorador)
+
+> Crea un componente contador con Pick Components usando `@Pick` con incremento, decremento y reinicio. Añádelo al `index.html` como contenido principal de la página.
+
+#### Contexto inline — `definePick` (sin decoradores)
+
+> Crea un componente contador con Pick Components usando `definePick` con incremento, decremento y reinicio. Añádelo al `index.html` como contenido principal de la página.
+
+#### Basado en clase — `@PickRender` (con decorador)
+
+> Crea un componente contador con Pick Components usando `@PickRender` con incremento, decremento y reinicio. Añádelo al `index.html` como contenido principal de la página.
+
+#### Basado en clase — `defineComponent` (sin decoradores)
+
+> Crea un componente contador con Pick Components usando `defineComponent` con incremento, decremento y reinicio. Añádelo al `index.html` como contenido principal de la página.
+
+---
+
+## Qué genera Copilot
+
+A continuación se muestran las salidas mínimas para cada estilo.
+
+### `@Pick`
+
+**`src/counter-app.ts`**
+```typescript
+import { Pick } from "pick-components";
+
+@Pick("counter-app", (ctx) => {
+  ctx.state({ count: 0 });
+
+  ctx.on("increment", (state) => { state.count++; });
+  ctx.on("decrement", (state) => { state.count--; });
+  ctx.on("reset",     (state) => { state.count = 0; });
+
+  ctx.html(`
+    <p>Contador: {{count}}</p>
+    <pick-action action="increment"><button type="button">+</button></pick-action>
+    <pick-action action="decrement"><button type="button">−</button></pick-action>
+    <pick-action action="reset"><button type="button">Reiniciar</button></pick-action>
+  `);
+})
+class CounterApp {}
+```
+
+**`src/bootstrap.ts`**
+```typescript
+import { bootstrapFramework, Services } from "pick-components/bootstrap";
+import "./counter-app.js";
+
+await bootstrapFramework(Services);
+```
+
+**`index.html`**
+```html
+<body>
+  <counter-app></counter-app>
+</body>
+```
+
+---
+
+### `definePick`
+
+```typescript
+import { definePick, bootstrapFramework, Services } from "pick-components";
+
+const counterDef = definePick<{ count: number }>("counter-app", (ctx) => {
+  ctx.state({ count: 0 });
+
+  ctx.on("increment", (state) => { state.count++; });
+  ctx.on("decrement", (state) => { state.count--; });
+  ctx.on("reset",     (state) => { state.count = 0; });
+
+  ctx.html(`
+    <p>Contador: {{count}}</p>
+    <pick-action action="increment"><button type="button">+</button></pick-action>
+    <pick-action action="decrement"><button type="button">−</button></pick-action>
+    <pick-action action="reset"><button type="button">Reiniciar</button></pick-action>
+  `);
+});
+
+await bootstrapFramework(Services, {}, { components: [counterDef] });
+```
+
+---
+
+### `@PickRender`
+
+```typescript
+import { PickComponent, PickRender, Reactive, PickViewActions } from "pick-components";
+
+@PickRender({
+  selector: "counter-app",
+  template: `
+    <p>Contador: {{count}}</p>
+    <pick-action action="increment"><button type="button">+</button></pick-action>
+    <pick-action action="decrement"><button type="button">−</button></pick-action>
+    <pick-action action="reset"><button type="button">Reiniciar</button></pick-action>
+  `,
+})
+export class CounterApp extends PickComponent {
+  @Reactive count = 0;
+
+  getViewActions(): PickViewActions {
+    return {
+      increment: () => { this.count++; },
+      decrement: () => { this.count--; },
+      reset:     () => { this.count = 0; },
+    };
+  }
+}
+```
+
+---
+
+### `defineComponent`
+
+```typescript
+import { PickComponent, Reactive, defineComponent, PickViewActions } from "pick-components";
+
+class CounterApp extends PickComponent {
+  @Reactive count = 0;
+
+  getViewActions(): PickViewActions {
+    return {
+      increment: () => { this.count++; },
+      decrement: () => { this.count--; },
+      reset:     () => { this.count = 0; },
+    };
+  }
+}
+
+export const counterDef = defineComponent(CounterApp, {
+  selector: "counter-app",
+  template: `
+    <p>Contador: {{count}}</p>
+    <pick-action action="increment"><button type="button">+</button></pick-action>
+    <pick-action action="decrement"><button type="button">−</button></pick-action>
+    <pick-action action="reset"><button type="button">Reiniciar</button></pick-action>
+  `,
+});
+```
+
+**`src/bootstrap.ts`**
+```typescript
+import { bootstrapFramework, Services } from "pick-components/bootstrap";
+import { counterDef } from "./counter-app.js";
+
+await bootstrapFramework(Services, {}, { components: [counterDef] });
+```
+
+---
+
+## ¿Qué estilo debo elegir?
+
+| | `@Pick` | `definePick` | `@PickRender` | `defineComponent` |
+|---|---|---|---|---|
+| **Decoradores** | sí | no | sí | no |
+| **Clase** | no | no | sí | sí |
+| **Estado mediante** | `ctx.state()` | `ctx.state()` | `@Reactive` | `@Reactive` |
+| **Acciones mediante** | `ctx.on()` | `ctx.on()` | `getViewActions()` | `getViewActions()` |
+| **Ideal para** | componentes inline compactos | inline sin decoradores | ciclo de vida completo | ciclo de vida completo, sin decoradores |
+
+Los cuatro estilos soportan `initializer`, `lifecycle`, `skeleton` y `errorTemplate` para hidratación asíncrona y estados de carga.
+
+---
+
+## Siguientes pasos
+
+Una vez que tu primer componente funcione:
+
+- Usa más prompts de Copilot para generar servicios, tests y configuración de DI
+- Lee [docs/USAGE-GUIDE.md](USAGE-GUIDE.md) para cobertura completa de funcionalidades
+- Lee [docs/DEPENDENCY-INJECTION.md](DEPENDENCY-INJECTION.md) para patrones de DI factory-first
+- Lee [docs/PICK-VS-PICKRENDER.es.md](PICK-VS-PICKRENDER.es.md) para una comparación detallada entre `@Pick` y `@PickRender`
+- Prueba el [playground interactivo](https://pick-components.github.io/pick-components/)
+
+### Prompts de seguimiento útiles para Copilot
+
+> Escribe un test unitario para mi componente `CounterApp` siguiendo el patrón AAA.
+
+> Añade un `PickInitializer` a `CounterApp` que cargue el contador inicial desde un `CounterService`.
+
+> Muéstrame cómo registrar `CounterService` en el composition root usando `Services`.
+
+> Añade un `PickLifecycleManager` a `CounterApp` que se suscriba a un observable de `CounterService`.

--- a/docs/GETTING-STARTED.es.md
+++ b/docs/GETTING-STARTED.es.md
@@ -86,7 +86,7 @@ Copilot producirá:
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Mi App</title>
-    <script type="module" src="./src/main.js"></script>
+    <script type="module" src="./src/bootstrap.js"></script>
   </head>
   <body>
     <!-- tus componentes van aquí -->
@@ -140,9 +140,11 @@ import { Pick } from "pick-components";
 @Pick("counter-app", (ctx) => {
   ctx.state({ count: 0 });
 
-  ctx.on("increment", (state) => { state.count++; });
-  ctx.on("decrement", (state) => { state.count--; });
-  ctx.on("reset",     (state) => { state.count = 0; });
+  ctx.on({
+    increment() { this.count++; },
+    decrement() { this.count--; },
+    reset()      { this.count = 0; },
+  });
 
   ctx.html(`
     <p>Contador: {{count}}</p>
@@ -179,9 +181,11 @@ import { definePick, bootstrapFramework, Services } from "pick-components";
 const counterDef = definePick<{ count: number }>("counter-app", (ctx) => {
   ctx.state({ count: 0 });
 
-  ctx.on("increment", (state) => { state.count++; });
-  ctx.on("decrement", (state) => { state.count--; });
-  ctx.on("reset",     (state) => { state.count = 0; });
+  ctx.on({
+    increment() { this.count++; },
+    decrement() { this.count--; },
+    reset()      { this.count = 0; },
+  });
 
   ctx.html(`
     <p>Contador: {{count}}</p>

--- a/docs/GETTING-STARTED.es.md
+++ b/docs/GETTING-STARTED.es.md
@@ -159,9 +159,9 @@ class CounterApp {}
 **`src/bootstrap.ts`**
 ```typescript
 import { bootstrapFramework, Services } from "pick-components/bootstrap";
-import "./counter-app.js";
 
 await bootstrapFramework(Services);
+await import("./counter-app.js"); // import dinámico: los decoradores se ejecutan después de registrar los servicios
 ```
 
 **`index.html`**

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -159,9 +159,9 @@ class CounterApp {}
 **`src/bootstrap.ts`**
 ```typescript
 import { bootstrapFramework, Services } from "pick-components/bootstrap";
-import "./counter-app.js";
 
 await bootstrapFramework(Services);
+await import("./counter-app.js"); // dynamic import: decorators run after services are registered
 ```
 
 **`index.html`**

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -1,0 +1,298 @@
+# Getting Started with Pick Components
+
+This guide walks you from a blank folder to your first running component. It assumes you have Node.js 18+ installed.
+
+---
+
+## Step 1 — Create your project
+
+```bash
+mkdir my-app && cd my-app
+npm init -y
+npm install typescript --save-dev
+```
+
+Add a minimal `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "moduleResolution": "bundler",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}
+```
+
+> If your bundler requires a different `moduleResolution`, adjust accordingly. Pick Components ships standard ESM and works with Vite, Rollup, Webpack, and esbuild.
+
+---
+
+## Step 2 — Install Pick Components
+
+```bash
+npm install pick-components
+```
+
+---
+
+## Step 3 — Set up the Copilot skill
+
+The Copilot skill teaches GitHub Copilot the Pick Components conventions so it generates correct components, tests, DI wiring, and templates — rather than guessing.
+
+Install into your project with:
+
+```bash
+npx --package=pick-components pick-components-copilot
+```
+
+This copies `.github/skills/setup-pick-components/` into your project. Commit the result so the whole team benefits.
+
+If you prefer to install manually, copy the `setup-pick-components/` skill folder from the [repository](https://github.com/pick-components/pick-components/tree/main/.github/skills/setup-pick-components) into `.github/skills/` in your project.
+
+---
+
+## Step 4 — Activate in Copilot chat
+
+Open GitHub Copilot chat (VS Code or the web) and type:
+
+```
+/setup-pick-components
+```
+
+Copilot loads the skill and is now ready to generate Pick Components code following framework conventions.
+
+---
+
+## Step 5 — Scaffold your project with Copilot
+
+### 5a. Generate the entry files
+
+Paste this prompt into Copilot chat:
+
+> Create a minimal `index.html` and `src/bootstrap.ts` for a Pick Components project using npm and a bundler.
+
+Copilot will produce:
+
+**`index.html`**
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>My App</title>
+    <script type="module" src="./src/main.js"></script>
+  </head>
+  <body>
+    <!-- your components go here -->
+  </body>
+</html>
+```
+
+**`src/bootstrap.ts`**
+```typescript
+import { bootstrapFramework, Services } from "pick-components/bootstrap";
+
+await bootstrapFramework(Services);
+```
+
+> `bootstrapFramework` must complete before any component module is imported. Use top-level `await` (ESM) to guarantee ordering.
+
+### 5b. Create your first component
+
+Choose the style you prefer and paste the matching prompt into Copilot chat.
+
+> **Tip:** tell Copilot where in the page the component should live so it also updates `index.html` for you. If it is the only component on the page, say "as the main page content". If it goes inside a specific section, describe that — e.g. "inside a `<main>` below a `<header>`".
+
+#### Inline context — `@Pick` (decorator)
+
+> Create a Pick Components counter component using `@Pick` with increment, decrement, and reset. Add it to `index.html` as the main page content.
+
+#### Inline context — `definePick` (no decorators)
+
+> Create a Pick Components counter component using `definePick` with increment, decrement, and reset. Add it to `index.html` as the main page content.
+
+#### Class-based — `@PickRender` (decorator)
+
+> Create a Pick Components counter component using `@PickRender` with increment, decrement, and reset. Add it to `index.html` as the main page content.
+
+#### Class-based — `defineComponent` (no decorators)
+
+> Create a Pick Components counter component using `defineComponent` with increment, decrement, and reset. Add it to `index.html` as the main page content.
+
+---
+
+## What Copilot generates
+
+Below are the minimal outputs for each style.
+
+### `@Pick`
+
+**`src/counter-app.ts`**
+```typescript
+import { Pick } from "pick-components";
+
+@Pick("counter-app", (ctx) => {
+  ctx.state({ count: 0 });
+
+  ctx.on("increment", (state) => { state.count++; });
+  ctx.on("decrement", (state) => { state.count--; });
+  ctx.on("reset",     (state) => { state.count = 0; });
+
+  ctx.html(`
+    <p>Count: {{count}}</p>
+    <pick-action action="increment"><button type="button">+</button></pick-action>
+    <pick-action action="decrement"><button type="button">−</button></pick-action>
+    <pick-action action="reset"><button type="button">Reset</button></pick-action>
+  `);
+})
+class CounterApp {}
+```
+
+**`src/bootstrap.ts`**
+```typescript
+import { bootstrapFramework, Services } from "pick-components/bootstrap";
+import "./counter-app.js";
+
+await bootstrapFramework(Services);
+```
+
+**`index.html`**
+```html
+<body>
+  <counter-app></counter-app>
+</body>
+```
+
+---
+
+### `definePick`
+
+```typescript
+import { definePick, bootstrapFramework, Services } from "pick-components";
+
+const counterDef = definePick<{ count: number }>("counter-app", (ctx) => {
+  ctx.state({ count: 0 });
+
+  ctx.on("increment", (state) => { state.count++; });
+  ctx.on("decrement", (state) => { state.count--; });
+  ctx.on("reset",     (state) => { state.count = 0; });
+
+  ctx.html(`
+    <p>Count: {{count}}</p>
+    <pick-action action="increment"><button type="button">+</button></pick-action>
+    <pick-action action="decrement"><button type="button">−</button></pick-action>
+    <pick-action action="reset"><button type="button">Reset</button></pick-action>
+  `);
+});
+
+await bootstrapFramework(Services, {}, { components: [counterDef] });
+```
+
+---
+
+### `@PickRender`
+
+```typescript
+import { PickComponent, PickRender, Reactive, PickViewActions } from "pick-components";
+
+@PickRender({
+  selector: "counter-app",
+  template: `
+    <p>Count: {{count}}</p>
+    <pick-action action="increment"><button type="button">+</button></pick-action>
+    <pick-action action="decrement"><button type="button">−</button></pick-action>
+    <pick-action action="reset"><button type="button">Reset</button></pick-action>
+  `,
+})
+export class CounterApp extends PickComponent {
+  @Reactive count = 0;
+
+  getViewActions(): PickViewActions {
+    return {
+      increment: () => { this.count++; },
+      decrement: () => { this.count--; },
+      reset:     () => { this.count = 0; },
+    };
+  }
+}
+```
+
+---
+
+### `defineComponent`
+
+```typescript
+import { PickComponent, Reactive, defineComponent, PickViewActions } from "pick-components";
+
+class CounterApp extends PickComponent {
+  @Reactive count = 0;
+
+  getViewActions(): PickViewActions {
+    return {
+      increment: () => { this.count++; },
+      decrement: () => { this.count--; },
+      reset:     () => { this.count = 0; },
+    };
+  }
+}
+
+export const counterDef = defineComponent(CounterApp, {
+  selector: "counter-app",
+  template: `
+    <p>Count: {{count}}</p>
+    <pick-action action="increment"><button type="button">+</button></pick-action>
+    <pick-action action="decrement"><button type="button">−</button></pick-action>
+    <pick-action action="reset"><button type="button">Reset</button></pick-action>
+  `,
+});
+```
+
+**`src/bootstrap.ts`**
+```typescript
+import { bootstrapFramework, Services } from "pick-components/bootstrap";
+import { counterDef } from "./counter-app.js";
+
+await bootstrapFramework(Services, {}, { components: [counterDef] });
+```
+
+---
+
+## Which style should I choose?
+
+| | `@Pick` | `definePick` | `@PickRender` | `defineComponent` |
+|---|---|---|---|---|
+| **Decorators** | yes | no | yes | no |
+| **Class** | no | no | yes | yes |
+| **State via** | `ctx.state()` | `ctx.state()` | `@Reactive` | `@Reactive` |
+| **Actions via** | `ctx.on()` | `ctx.on()` | `getViewActions()` | `getViewActions()` |
+| **Best for** | compact inline | no-decorator inline | full lifecycle | full lifecycle, no-decorator |
+
+All four styles support `initializer`, `lifecycle`, `skeleton`, and `errorTemplate` for async hydration and loading states.
+
+---
+
+## Next steps
+
+Once your first component works:
+
+- Add more Copilot prompts to generate services, tests, and DI wiring
+- Read [docs/USAGE-GUIDE.md](USAGE-GUIDE.md) for full feature coverage
+- Read [docs/DEPENDENCY-INJECTION.md](DEPENDENCY-INJECTION.md) for factory-first DI patterns
+- Read [docs/PICK-VS-PICKRENDER.md](PICK-VS-PICKRENDER.md) for a detailed comparison between `@Pick` and `@PickRender`
+- Try the [live playground](https://pick-components.github.io/pick-components/) for interactive examples
+
+### Useful follow-up Copilot prompts
+
+> Write a unit test for my `CounterApp` component following AAA pattern.
+
+> Add a `PickInitializer` to `CounterApp` that loads the initial count from a `CounterService`.
+
+> Show me how to register `CounterService` in the composition root using `Services`.
+
+> Add a `PickLifecycleManager` to `CounterApp` that subscribes to a `CounterService` observable.

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -86,7 +86,7 @@ Copilot will produce:
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>My App</title>
-    <script type="module" src="./src/main.js"></script>
+    <script type="module" src="./src/bootstrap.js"></script>
   </head>
   <body>
     <!-- your components go here -->
@@ -140,9 +140,11 @@ import { Pick } from "pick-components";
 @Pick("counter-app", (ctx) => {
   ctx.state({ count: 0 });
 
-  ctx.on("increment", (state) => { state.count++; });
-  ctx.on("decrement", (state) => { state.count--; });
-  ctx.on("reset",     (state) => { state.count = 0; });
+  ctx.on({
+    increment() { this.count++; },
+    decrement() { this.count--; },
+    reset()      { this.count = 0; },
+  });
 
   ctx.html(`
     <p>Count: {{count}}</p>
@@ -179,9 +181,11 @@ import { definePick, bootstrapFramework, Services } from "pick-components";
 const counterDef = definePick<{ count: number }>("counter-app", (ctx) => {
   ctx.state({ count: 0 });
 
-  ctx.on("increment", (state) => { state.count++; });
-  ctx.on("decrement", (state) => { state.count--; });
-  ctx.on("reset",     (state) => { state.count = 0; });
+  ctx.on({
+    increment() { this.count++; },
+    decrement() { this.count--; },
+    reset()      { this.count = 0; },
+  });
 
   ctx.html(`
     <p>Count: {{count}}</p>

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -5,6 +5,8 @@ Esta carpeta contiene la documentación canónica de Pick Components.
 ## Primeros Pasos
 
 - [WHY-PICK-COMPONENTS.md](WHY-PICK-COMPONENTS.md) - Motivación y origen del proyecto.
+- [GETTING-STARTED.md](GETTING-STARTED.md) - Guía paso a paso: proyecto → npm → skill → primer componente (EN).
+- [GETTING-STARTED.es.md](GETTING-STARTED.es.md) - Traducción al español.
 - [USAGE-GUIDE.md](USAGE-GUIDE.md) - Guía completa (EN) de setup, bootstrap, uso y playground.
 - [PICK-VS-PICKRENDER.md](PICK-VS-PICKRENDER.md) - Cuándo usar `@Pick` frente a `@PickRender`.
 - [PICK-VS-PICKRENDER.es.md](PICK-VS-PICKRENDER.es.md) - Traducción al español.

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,8 @@ This folder contains the canonical documentation for Pick Components.
 ## Getting Started
 
 - [WHY-PICK-COMPONENTS.md](WHY-PICK-COMPONENTS.md) - Project motivation and origin story.
+- [GETTING-STARTED.md](GETTING-STARTED.md) - Step-by-step guide: project → npm → skill → first component.
+- [GETTING-STARTED.es.md](GETTING-STARTED.es.md) - Spanish translation.
 - [USAGE-GUIDE.md](USAGE-GUIDE.md) - Full setup, bootstrap, usage examples, and playground workflow.
 - [PICK-VS-PICKRENDER.md](PICK-VS-PICKRENDER.md) - When to use `@Pick` vs `@PickRender`.
 - [PICK-VS-PICKRENDER.es.md](PICK-VS-PICKRENDER.es.md) - Spanish translation.

--- a/examples/src/demos/18-define-pick/variants/en-dark/counter.example.ts
+++ b/examples/src/demos/18-define-pick/variants/en-dark/counter.example.ts
@@ -20,9 +20,9 @@ export const counterDef = definePick<{ count: number }>("counter-example", (ctx)
     <div class="counter">
       <p>Counter: {{count}}</p>
       <div class="actions">
-        <button pick-action="decrement" type="button">−</button>
-        <button pick-action="reset" type="button">Reset</button>
-        <button pick-action="increment" type="button">+</button>
+        <pick-action action="decrement"><button type="button">−</button></pick-action>
+        <pick-action action="reset"><button type="button">Reset</button></pick-action>
+        <pick-action action="increment"><button type="button">+</button></pick-action>
       </div>
     </div>
   `);

--- a/examples/src/demos/18-define-pick/variants/en-light/counter.example.ts
+++ b/examples/src/demos/18-define-pick/variants/en-light/counter.example.ts
@@ -20,9 +20,9 @@ export const counterDef = definePick<{ count: number }>("counter-example", (ctx)
     <div class="counter">
       <p>Counter: {{count}}</p>
       <div class="actions">
-        <button pick-action="decrement" type="button">−</button>
-        <button pick-action="reset" type="button">Reset</button>
-        <button pick-action="increment" type="button">+</button>
+        <pick-action action="decrement"><button type="button">−</button></pick-action>
+        <pick-action action="reset"><button type="button">Reset</button></pick-action>
+        <pick-action action="increment"><button type="button">+</button></pick-action>
       </div>
     </div>
   `);

--- a/examples/src/demos/18-define-pick/variants/es-dark/counter.example.ts
+++ b/examples/src/demos/18-define-pick/variants/es-dark/counter.example.ts
@@ -20,9 +20,9 @@ export const counterDef = definePick<{ count: number }>("counter-example", (ctx)
     <div class="counter">
       <p>Contador: {{count}}</p>
       <div class="actions">
-        <button pick-action="decrement" type="button">−</button>
-        <button pick-action="reset" type="button">Reiniciar</button>
-        <button pick-action="increment" type="button">+</button>
+        <pick-action action="decrement"><button type="button">−</button></pick-action>
+        <pick-action action="reset"><button type="button">Reiniciar</button></pick-action>
+        <pick-action action="increment"><button type="button">+</button></pick-action>
       </div>
     </div>
   `);

--- a/examples/src/demos/18-define-pick/variants/es-light/counter.example.ts
+++ b/examples/src/demos/18-define-pick/variants/es-light/counter.example.ts
@@ -20,9 +20,9 @@ export const counterDef = definePick<{ count: number }>("counter-example", (ctx)
     <div class="counter">
       <p>Contador: {{count}}</p>
       <div class="actions">
-        <button pick-action="decrement" type="button">−</button>
-        <button pick-action="reset" type="button">Reiniciar</button>
-        <button pick-action="increment" type="button">+</button>
+        <pick-action action="decrement"><button type="button">−</button></pick-action>
+        <pick-action action="reset"><button type="button">Reiniciar</button></pick-action>
+        <pick-action action="increment"><button type="button">+</button></pick-action>
       </div>
     </div>
   `);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pick-components",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "A tiny lifecycle-focused framework for building reactive web components",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/tests/unit/decorators/define-pick.test.ts
+++ b/tests/unit/decorators/define-pick.test.ts
@@ -184,12 +184,14 @@ test.describe("definePick — ctx.on view actions", () => {
 
     const state = { count: 0 } as any;
 
-    // Act
+    // Act & Assert — verify each step independently
     config.methods!["increment"].call(state);
-    config.methods!["increment"].call(state);
-    config.methods!["reset"].call(state);
+    expect(state.count).toBe(1);
 
-    // Assert
+    config.methods!["increment"].call(state);
+    expect(state.count).toBe(2);
+
+    config.methods!["reset"].call(state);
     expect(state.count).toBe(0);
   });
 });

--- a/tests/unit/decorators/define-pick.test.ts
+++ b/tests/unit/decorators/define-pick.test.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "@playwright/test";
 import { definePick } from "../../../src/decorators/define-pick.js";
+import { DefaultPickComponentFactory } from "../../../src/decorators/pick/pick-component-factory.js";
 import type { ComponentDefinition } from "../../../src/providers/framework-bootstrap.js";
+import type { IListenerMetadataRegistry } from "../../../src/decorators/listen/listener-metadata-registry.interface.js";
 
 /**
  * Tests for definePick responsibility.
@@ -124,5 +126,70 @@ test.describe("definePick", () => {
     expect(() =>
       definePick("my-comp ", setup),
     ).toThrow("[definePick] selector must not have leading or trailing whitespace");
+  });
+});
+
+test.describe("definePick — ctx.on view actions", () => {
+  // Minimal mock: IListenerMetadataRegistry is only needed by factory internals for @Listen,
+  // not used when calling captureConfig with a plain ctx.on setup.
+  const mockListenerRegistry: IListenerMetadataRegistry = {
+    register: () => {},
+    get: () => [],
+  };
+
+  test("should capture ctx.on handlers as methods in the config", () => {
+    // Arrange
+    const counterDef = definePick<{ count: number }>("def-pick-counter", (ctx) => {
+      ctx.state({ count: 0 });
+      ctx.on({
+        increment() { this.count++; },
+        decrement() { this.count--; },
+        reset() { this.count = 0; },
+      });
+      ctx.html(`
+        <div>
+          <p>{{count}}</p>
+          <pick-action action="increment"><button type="button">+</button></pick-action>
+          <pick-action action="decrement"><button type="button">-</button></pick-action>
+          <pick-action action="reset"><button type="button">Reset</button></pick-action>
+        </div>
+      `);
+    });
+    const factory = new DefaultPickComponentFactory(mockListenerRegistry);
+
+    // Act
+    const config = factory.captureConfig<{ count: number }>(counterDef.setup as any);
+
+    // Assert — all three action names must be present in config.methods
+    expect(typeof config.methods?.["increment"]).toBe("function");
+    expect(typeof config.methods?.["decrement"]).toBe("function");
+    expect(typeof config.methods?.["reset"]).toBe("function");
+  });
+
+  test("should invoke ctx.on handler mutating state when called with bound context", () => {
+    // Arrange
+    const counterDef = definePick<{ count: number }>("def-pick-state-counter", (ctx) => {
+      ctx.state({ count: 0 });
+      ctx.on({
+        increment() { this.count++; },
+        reset() { this.count = 0; },
+      });
+      ctx.html(`
+        <pick-action action="increment"><button type="button">+</button></pick-action>
+        <pick-action action="reset"><button type="button">Reset</button></pick-action>
+      `);
+    });
+    const factory = new DefaultPickComponentFactory(mockListenerRegistry);
+    const config = factory.captureConfig<{ count: number }>(counterDef.setup as any);
+
+    const state = { count: 0 } as any;
+
+    // Act
+    config.methods!["increment"].call(state);
+    config.methods!["increment"].call(state);
+    config.methods!["reset"].call(state);
+
+    // Assert
+    expect(state.count).toBe(0);
   });
 });


### PR DESCRIPTION
### What

**Bug fix:** The `18-define-pick` playground example used `pick-action` as an HTML attribute (`<button pick-action="increment">`) instead of as a custom element wrapper. The buttons had no effect. Fixed in all 4 locale variants.

**Skill:** The Copilot skill (`/setup-pick-components`) only documented `@PickRender`. Added coverage for all four Pick Components APIs.

**Docs:** New step-by-step getting started guide for new users.

### Changes

#### Fixed
- 18-define-pick — all 4 variants: `<button pick-action="…">` → `<pick-action action="…"><button>…</button></pick-action>`

#### Tests
- define-pick.test.ts — 2 new tests for `ctx.on`: captures handlers in `config.methods` and mutates state correctly when invoked

#### Skill (`/setup-pick-components`)
- 01-create-components.md — 4-API comparison table, `@Pick`, `definePick`, `defineComponent` sections, `getViewActions()` patterns, `pick-action` custom element warning, `defineComponent` + `initializer`/`lifecycle`/`skeleton`/`errorTemplate` config
- `05-inline-context-api.md` *(new)* — complete `ctx.*` reference for `@Pick`/`definePick`
- SKILL.md — updated description with all API names and `ctx.*` keywords for better AI discovery

#### Docs
- GETTING-STARTED.md + GETTING-STARTED.es.md *(new)* — project → npm → skill → first component in any of the 4 styles, with copy-paste Copilot prompts
- README.md, README.es.md, README.md — updated with GETTING-STARTED links
- copilot-instructions.md — fixed broken `SETUP.md` link