### PR TITLE
fix(ci): pass required tag input when triggering release.yml

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -71,4 +71,4 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run release.yml --ref "v${{ steps.version.outputs.version }}"
+          gh workflow run release.yml --ref "v${{ steps.version.outputs.version }}" --field tag="v${{ steps.version.outputs.version }}"


### PR DESCRIPTION
gh workflow run needs --field tag=... in addition to --ref so that the workflow_dispatch input 'tag' is populated. Without it GitHub returns HTTP 422 'Required input tag not provided'.