### PR TITLE
docs: expandir cobertura en español y clarificar guía de adopción/integración

### DIFF
--- a/.github/skills/setup-pick-components/01-create-components.md
+++ b/.github/skills/setup-pick-components/01-create-components.md
@@ -13,6 +13,19 @@ Pick Components has **four APIs** depending on how much decorator/class syntax y
 | `@Pick` | Inline context (decorator, but setup via `ctx.*`) |
 | `definePick` | Fully decorator-free, functional — no class, no `@Reactive`, no `@Listen` |
 
+## Existing App Integration (Incremental)
+
+You can adopt Pick Components inside existing React/Vue projects without full migration.
+
+- Prefer a dedicated bootstrap entry for the screen/area where Pick is used.
+- Register only the components needed for that integration point.
+- Consume Pick components as native custom elements.
+
+Prompt examples for Copilot:
+
+- `Integrate a Pick Components widget into an existing React page using a dedicated bootstrap entry and a custom element mount point.`
+- `Generate a definePick component intended for incremental adoption inside a Vue app section, with explicit bootstrap registration.`
+
 ### `pick-action` — ALWAYS a custom element
 
 **`<pick-action>` is a custom element, not an HTML attribute.** It wraps the interactive element:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `docs/USAGE-GUIDE.es.md` as the Spanish companion for the full usage guide, including setup modes, bootstrap order, decorator-free APIs, template safety, and playground workflow.
+
+### Changed
+- Updated `README.md` with direct links to Spanish documentation (`docs/README.es.md`, `docs/GETTING-STARTED.es.md`, and `docs/USAGE-GUIDE.es.md`) and improved Start Paths navigation.
+- Updated `docs/README.md` and `docs/README.es.md` to include `USAGE-GUIDE.es.md` in the docs index.
+- Expanded `docs/PICK-VS-OTHERS.md` and `docs/PICK-VS-OTHERS.es.md` with React/Vue/Svelte coverage, clearer coexistence guidance, and less repetitive framework-specific wording.
+- Updated `docs/DEPENDENCY-INJECTION.md` and `docs/DEPENDENCY-INJECTION.es.md` to document `Services.get()` lazy singleton behavior and `Services.getNew()` transient behavior.
+- Updated `docs/GETTING-STARTED.md`, `docs/GETTING-STARTED.es.md`, and `docs/USAGE-GUIDE.md` with incremental-adoption guidance for integrating Pick Components into existing React/Vue applications.
+- Updated `.github/skills/setup-pick-components/01-create-components.md` with incremental integration prompt patterns for existing frontend applications.
+
 ## [1.0.8] - 2026-05-10
 
 ### Added

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,138 @@
+<p>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/pick-components/pick-components/main/.github/brand/logo-expanded-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/pick-components/pick-components/main/.github/brand/logo-expanded-light.svg">
+    <img src="https://raw.githubusercontent.com/pick-components/pick-components/main/.github/brand/logo-expanded-dark.svg" alt="Pick Components" width="420">
+  </picture>
+</p>
+
+> Framework ligero y reactivo de Web Components para TypeScript y ESM moderno en navegador.  
+> La lógica de negocio vive en servicios. Los componentes son presentacionales.
+
+Versión canónica en inglés: [README.md](README.md)
+
+Prueba el playground en vivo: <https://pick-components.github.io/pick-components/>
+
+[![npm](https://img.shields.io/npm/v/pick-components)](https://www.npmjs.com/package/pick-components)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.0%2B-blue)](https://www.typescriptlang.org/)
+
+---
+
+## Características
+
+- **Reactividad basada en señales** - Señales por propiedad; solo se re-ejecutan los bindings que dependen del estado cambiado.
+- **Signals de intención del componente** - Acciones one-shot tipadas como guardar, refrescar o cambiar de modo, separadas del estado de render.
+- **Sin virtual DOM** - Suscripciones directas actualizan nodos de texto y atributos in-place.
+- **Dos estilos de autoría** - `@Pick` inline para componentes compactos; `@PickRender` basado en clase para estructura explícita.
+- **Primitivas UI incluidas** - `<pick-for>`, `<pick-select>`, `<pick-action>`, `<pick-link>` y `<pick-router>` cubren listas, ramas, acciones y navegación.
+- **Proyección nativa de slots** - `<slot>` con nombre y por defecto para layouts componibles vía Shadow DOM.
+- **DI factory-first** - Inyección de dependencias explícita mediante factories; sin construcción oculta de servicios.
+- **Evaluador de expresiones orientado a seguridad** - Pipeline AST determinista; sin `eval` ni `new Function`.
+- **Adopción SEO-friendly de prerender** - Entrega HTML-first con adopción en cliente de markup prerenderizado compatible.
+- **Huella mínima** - Cero dependencias runtime.
+- **Releases ESM listos para navegador** - Los artefactos de GitHub Release se pueden cargar directamente con `<script type="module">`.
+
+---
+
+## Por qué existe Pick Components
+
+La historia completa del proyecto está en [docs/WHY-PICK-COMPONENTS.es.md](docs/WHY-PICK-COMPONENTS.es.md).
+
+Resumen corto: este framework se creó para mantener los Web Components nativos explícitos, predecibles y mantenibles, con seguridad estricta en templates y una superficie runtime más pequeña.
+
+---
+
+## Instalación
+
+```bash
+npm install pick-components
+```
+
+## Quickstart (npm + bundler)
+
+```typescript
+import { bootstrapFramework, Services, Pick } from "pick-components";
+
+await bootstrapFramework(Services);
+
+@Pick("hello-card", (ctx) => {
+  ctx.state({ name: "world" });
+  ctx.html(`<p>Hello {{name}}</p>`);
+})
+class HelloCard {}
+```
+
+Es la ruta más rápida para Vite, Rollup, Webpack, esbuild u otros toolchains similares.
+
+## Quickstart (sin decoradores)
+
+```typescript
+import {
+  bootstrapFramework,
+  Services,
+  definePick,
+} from "pick-components";
+
+const helloDef = definePick<{ name: string }>("hello-card", (ctx) => {
+  ctx.state({ name: "world" });
+  ctx.html(`<p>Hello {{name}}</p>`);
+});
+
+await bootstrapFramework(Services, {}, {
+  components: [helloDef],
+});
+```
+
+Puedes registrar componentes sin `@Pick` ni `@PickRender` usando descriptores `definePick` y `defineComponent` mediante la opción `components`.
+
+## Setup de Copilot AI (Opcional)
+
+¿Quieres que Copilot siga las convenciones de Pick Components para componentes, DI, tests y templates?
+
+Consulta la guía completa en [docs/USAGE-GUIDE.es.md#setup-de-copilot-ai-opcional](docs/USAGE-GUIDE.es.md#setup-de-copilot-ai-opcional).
+
+---
+
+## Rutas de inicio
+
+- **Quiero construir ya (npm + bundler):** quédate en este README y usa el Quickstart de arriba.
+- **Quiero una guía paso a paso con Copilot:** ve a [docs/GETTING-STARTED.es.md](docs/GETTING-STARTED.es.md).
+- **Quiero trabajar sin decoradores:** ve a [docs/USAGE-GUIDE.es.md#uso-sin-decoradores-definecomponent-y-definepick](docs/USAGE-GUIDE.es.md#uso-sin-decoradores-definecomponent-y-definepick).
+- **Quiero setup de Copilot:** ve a [docs/USAGE-GUIDE.es.md#setup-de-copilot-ai-opcional](docs/USAGE-GUIDE.es.md#setup-de-copilot-ai-opcional).
+- **Quiero browser ESM plano (sin bundler):** ve a [docs/USAGE-GUIDE.es.md](docs/USAGE-GUIDE.es.md).
+- **Quiero detalles de arquitectura y DI:** ve a [docs/DEPENDENCY-INJECTION.es.md](docs/DEPENDENCY-INJECTION.es.md) y [docs/RENDERING-ARCHITECTURE.es.md](docs/RENDERING-ARCHITECTURE.es.md).
+- **Quiero comparativas con frameworks (React, Vue, Lit, Angular, Svelte, Glimmer):** ve a [docs/PICK-VS-OTHERS.es.md](docs/PICK-VS-OTHERS.es.md).
+- **Quiero la referencia completa de uso, decoradores, acciones, templates y playground:** ve a [docs/USAGE-GUIDE.es.md](docs/USAGE-GUIDE.es.md).
+- **Prefiero leer la documentación en inglés:** ve a [README.md](README.md) y [docs/README.md](docs/README.md).
+
+## Ejecutar en local
+
+```bash
+npm install
+npm run build
+npm run serve:dev
+```
+
+Playground: `http://localhost:3000`
+
+---
+
+## Documentación
+
+- [docs/README.es.md](https://github.com/pick-components/pick-components/blob/main/docs/README.es.md) - Índice principal de documentación en español.
+- [docs/WHY-PICK-COMPONENTS.es.md](https://github.com/pick-components/pick-components/blob/main/docs/WHY-PICK-COMPONENTS.es.md) - Origen y motivación del proyecto en español.
+- [docs/USAGE-GUIDE.es.md](https://github.com/pick-components/pick-components/blob/main/docs/USAGE-GUIDE.es.md) - Guía completa en español (setup, uso y playground).
+- [docs/GETTING-STARTED.es.md](https://github.com/pick-components/pick-components/blob/main/docs/GETTING-STARTED.es.md) - Guía paso a paso en español.
+- [docs/README.md](https://github.com/pick-components/pick-components/blob/main/docs/README.md) - Main documentation index (English).
+- [CHANGELOG.md](https://github.com/pick-components/pick-components/blob/main/CHANGELOG.md) - Historial de versiones y cambios relevantes.
+
+---
+
+## Nota de idioma
+
+La fuente de verdad del proyecto se mantiene en inglés. Las traducciones al español se publican como documentación complementaria para facilitar la adopción.
+
+## Licencia
+
+[MIT](LICENSE) © janmbaco

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 > A lightweight, reactive web components framework for TypeScript and modern browser ESM.  
 > Business logic stays in services. Components are pure presentation.
 
+Spanish quick entry: [README.es.md](README.es.md)
+
 Try the live playground: <https://pick-components.github.io/pick-components/>
 
 [![npm](https://img.shields.io/npm/v/pick-components)](https://www.npmjs.com/package/pick-components)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ See the full setup guide in [docs/USAGE-GUIDE.md#copilot-ai-setup-optional](docs
 - **I want Copilot setup:** see [docs/USAGE-GUIDE.md#copilot-ai-setup-optional](docs/USAGE-GUIDE.md#copilot-ai-setup-optional).
 - **I want plain browser ESM (no bundler):** see [docs/USAGE-GUIDE.md](docs/USAGE-GUIDE.md).
 - **I want architecture and DI details:** see [docs/DEPENDENCY-INJECTION.md](docs/DEPENDENCY-INJECTION.md) and [docs/RENDERING-ARCHITECTURE.md](docs/RENDERING-ARCHITECTURE.md).
+- **I want framework comparisons (React, Vue, Lit, Angular, Svelte, Glimmer):** see [docs/PICK-VS-OTHERS.md](docs/PICK-VS-OTHERS.md).
 - **I want full usage, decorators, actions, templates, and playground workflow:** see [docs/USAGE-GUIDE.md](docs/USAGE-GUIDE.md).
+- **I prefer Spanish docs:** see [docs/README.es.md](docs/README.es.md), [docs/GETTING-STARTED.es.md](docs/GETTING-STARTED.es.md), and [docs/USAGE-GUIDE.es.md](docs/USAGE-GUIDE.es.md).
 
 ## Run Locally
 
@@ -119,6 +121,8 @@ Playground: `http://localhost:3000`
 - [docs/README.md](https://github.com/pick-components/pick-components/blob/main/docs/README.md) - Main documentation index (English).
 - [docs/README.es.md](https://github.com/pick-components/pick-components/blob/main/docs/README.es.md) - Índice principal de documentación (español).
 - [docs/USAGE-GUIDE.md](https://github.com/pick-components/pick-components/blob/main/docs/USAGE-GUIDE.md) - Full setup, usage, and playground workflow.
+- [docs/USAGE-GUIDE.es.md](https://github.com/pick-components/pick-components/blob/main/docs/USAGE-GUIDE.es.md) - Guía completa en español.
+- [docs/GETTING-STARTED.es.md](https://github.com/pick-components/pick-components/blob/main/docs/GETTING-STARTED.es.md) - Guía paso a paso en español.
 - [CHANGELOG.md](https://github.com/pick-components/pick-components/blob/main/CHANGELOG.md) - Release history and notable changes.
 
 ---

--- a/docs/DEPENDENCY-INJECTION.es.md
+++ b/docs/DEPENDENCY-INJECTION.es.md
@@ -19,6 +19,36 @@ Services.register(ApiService, () => new ApiService());
 Services.register(Logger, () => new Logger());
 ```
 
+### Semántica de ciclo de vida en `Services`
+
+- `Services.get(token)`:
+  para registros con factory (`() => ...`) crea la instancia en el primer acceso y la reutiliza después (Lazy Singleton por defecto).
+- `Services.getNew(token)`:
+  para registros con factory crea siempre una instancia nueva (Transient).
+- Si registras una instancia directa (`Services.register(Token, instancia)`), `getNew(token)` lanza error porque no existe factory para construir un nuevo objeto.
+
+```typescript
+import { Services } from "pick-components";
+
+let nextId = 1;
+
+class SessionService {
+  constructor(public readonly id = nextId++) {}
+}
+
+Services.register(SessionService, () => new SessionService());
+
+const singletonA = Services.get(SessionService);
+const singletonB = Services.get(SessionService);
+// true: get() reutiliza la instancia cacheada (lazy singleton)
+console.log(singletonA === singletonB);
+
+const transientA = Services.getNew(SessionService);
+const transientB = Services.getNew(SessionService);
+// false: getNew() crea instancias frescas (transient)
+console.log(transientA === transientB);
+```
+
 ## DI con @PickRender
 
 Provee dependencias via factories de `initializer` y `lifecycle`:

--- a/docs/DEPENDENCY-INJECTION.md
+++ b/docs/DEPENDENCY-INJECTION.md
@@ -19,6 +19,36 @@ Services.register(ApiService, () => new ApiService());
 Services.register(Logger, () => new Logger());
 ```
 
+### Service Lifecycle Semantics in `Services`
+
+- `Services.get(token)`:
+  for factory registrations (`() => ...`), creates the instance on first access and reuses it after that (Lazy Singleton by default).
+- `Services.getNew(token)`:
+  for factory registrations, always returns a fresh instance (Transient).
+- If you register a direct instance (`Services.register(Token, instance)`), `getNew(token)` throws because there is no factory to create a new object.
+
+```typescript
+import { Services } from "pick-components";
+
+let nextId = 1;
+
+class SessionService {
+  constructor(public readonly id = nextId++) {}
+}
+
+Services.register(SessionService, () => new SessionService());
+
+const singletonA = Services.get(SessionService);
+const singletonB = Services.get(SessionService);
+// true: get() reuses the cached instance (lazy singleton)
+console.log(singletonA === singletonB);
+
+const transientA = Services.getNew(SessionService);
+const transientB = Services.getNew(SessionService);
+// false: getNew() creates fresh instances (transient)
+console.log(transientA === transientB);
+```
+
 ## DI with @PickRender
 
 Provide dependencies through `initializer` and `lifecycle` factories:

--- a/docs/GETTING-STARTED.es.md
+++ b/docs/GETTING-STARTED.es.md
@@ -279,6 +279,18 @@ await bootstrapFramework(Services, {}, { components: [counterDef] });
 
 Los cuatro estilos soportan `initializer`, `lifecycle`, `skeleton` y `errorTemplate` para hidratación asíncrona y estados de carga.
 
+## Adopción incremental en apps existentes
+
+Si ya tienes una app en React o Vue, puedes adoptar Pick Components de forma incremental.
+
+- Empieza con un widget o sección aislada.
+- Registra los componentes Pick en ese entry point local.
+- Usa custom elements en vistas concretas sin migrar toda la base de código.
+
+Prompt útil para Copilot:
+
+> Integra un widget de Pick Components en una página React existente usando un custom element y un bootstrap entry dedicado.
+
 ---
 
 ## Siguientes pasos

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -279,6 +279,18 @@ await bootstrapFramework(Services, {}, { components: [counterDef] });
 
 All four styles support `initializer`, `lifecycle`, `skeleton`, and `errorTemplate` for async hydration and loading states.
 
+## Incremental adoption in existing apps
+
+If you already have a React or Vue app, you can adopt Pick Components incrementally.
+
+- Start with one isolated widget or section.
+- Register Pick components in that local entry point.
+- Use custom elements in targeted views without migrating the entire codebase.
+
+Useful Copilot prompt:
+
+> Integrate a Pick Components widget into an existing React page using a custom element and a dedicated bootstrap entry.
+
 ---
 
 ## Next steps

--- a/docs/PICK-VS-OTHERS.es.md
+++ b/docs/PICK-VS-OTHERS.es.md
@@ -34,7 +34,7 @@ Si ya usas Lit y cubre tus necesidades, mantener Lit es una decisión totalmente
 
 ### No es Angular
 
-Angular es un framework completo de aplicación con sistema de módulos, contenedor de inyección de dependencias, detección de cambios basada en zones, CLI, compilación AOT y una estructura de proyecto opinionada.
+Angular es un framework completo de aplicación con sistema de módulos, contenedor de inyección de dependencias, detección de cambios basada en zones, CLI, compilación AOT y una estructura de proyecto muy concreta.
 
 Pick Components es un framework de componentes, no de aplicación. No tiene router más allá de `<pick-router>` para el caso simple, ni sistema de módulos, ni CLI, ni paso AOT, ni zone.js. La inyección de dependencias es explícita y factory-first — no hay contenedor que auto-descubra o auto-conecte servicios.
 

--- a/docs/PICK-VS-OTHERS.es.md
+++ b/docs/PICK-VS-OTHERS.es.md
@@ -1,4 +1,4 @@
-# Pick Components vs Lit / Angular / Glimmer
+# Pick Components vs React / Vue / Lit / Angular / Svelte / Glimmer
 
 Este documento explica qué es Pick Components y qué no es, para ayudar a los desarrolladores que vienen de otros frameworks a calibrar las expectativas.
 
@@ -6,13 +6,31 @@ Este documento explica qué es Pick Components y qué no es, para ayudar a los d
 
 ## Lo que Pick Components no es
 
+### No es React
+
+React es una librería de UI centrada en JSX, estado con hooks y reconciliación sobre un árbol virtual de componentes.
+
+Pick Components apunta directamente a custom elements nativos. No hay árbol virtual gestionado por framework entre tu componente y el navegador, ni runtime de hooks.
+
+Eso no impide integrarlo dentro de una app React: puedes consumir componentes de Pick como custom elements en pantallas concretas sin migrar toda la base.
+
+Si React ya os da velocidad y estabilidad, lo más práctico suele ser continuar ahí y evaluar Pick solo para casos concretos.
+
+### No es Vue
+
+Vue es un framework progresivo con convenciones de SFC, un sistema reactivo basado en refs/proxies y patrones de aplicación para routing y stores.
+
+Pick Components no define un modelo SFC ni una capa de framework de aplicación. Se centra en custom elements nativos explícitos, servicios explícitos y factories de lifecycle predecibles.
+
+Con un stack Vue consolidado, suele tener más sentido comparar por caso de uso que plantear una migración general.
+
 ### No es un reemplazo de Lit
 
 Lit es una librería mantenida por Google para construir Web Components con template literals etiquetados (`html\`...\``), reflexión de propiedades y un sistema de actualización reactiva que compara valores de atributos y propiedades.
 
 Pick Components no usa template literals etiquetados. Los templates son cadenas HTML planas compiladas en tiempo de ejecución en un grafo de bindings reactivos. El modelo de binding es explícito y está basado en propiedades de estado nombradas — no hay diffing de DOM virtual ni ciclo de reflexión de propiedades.
 
-Si ya usas Lit y cubre tus necesidades, no hay razón para cambiar.
+Si ya usas Lit y cubre tus necesidades, mantener Lit es una decisión totalmente válida.
 
 ### No es Angular
 
@@ -20,11 +38,23 @@ Angular es un framework completo de aplicación con sistema de módulos, contene
 
 Pick Components es un framework de componentes, no de aplicación. No tiene router más allá de `<pick-router>` para el caso simple, ni sistema de módulos, ni CLI, ni paso AOT, ni zone.js. La inyección de dependencias es explícita y factory-first — no hay contenedor que auto-descubra o auto-conecte servicios.
 
+Para equipos cómodos con Angular CLI, DI y su ecosistema, cambiar solo por cambiar rara vez compensa.
+
+### No es Svelte
+
+Svelte se apoya en transformaciones en tiempo de compilación que reescriben código y templates a operaciones DOM imperativas.
+
+Pick Components no requiere paso de compilación. Los templates son cadenas HTML planas interpretadas en runtime por un motor de bindings determinista, y el cableado del componente permanece explícito en factories y hooks de lifecycle.
+
+Si vuestro flujo depende de las ventajas del compilador de Svelte, lo razonable suele ser seguir con ese enfoque.
+
 ### No es Glimmer
 
 Glimmer VM es la capa de renderizado dentro de Ember. Usa un formato de bytecode compilado para los templates, un modelo de reactividad basado en referencias y un árbol de propietarios estricto para la propiedad de componentes.
 
 Pick Components compila los templates en tiempo de ejecución en el navegador, no en tiempo de build. No hay bytecode, no hay modelo de propietario de Ember, y no hay contrato de clase `glimmer-component` que implementar.
+
+En proyectos asentados sobre Ember/Glimmer, Pick suele encajar mejor como referencia comparativa que como sustitución inmediata.
 
 ---
 
@@ -60,15 +90,17 @@ El paquete npm no tiene dependencias en runtime. La distribución lista para el 
 
 ## Tabla comparativa rápida
 
-| Aspecto | Pick Components | Lit | Angular | Glimmer |
-| ------- | --------------- | --- | ------- | ------- |
-| Sintaxis de templates | `{{prop}}` en cadenas HTML | Template literals etiquetados | `{{ prop }}` en ficheros `.html` | `{{prop}}` en ficheros `.hbs` |
-| Modelo de reactividad | Basado en señales, suscripciones por propiedad | Reflexión de propiedades + ciclo de actualización | Zone.js + detección de cambios | Referencias rastreadas + autotracking |
-| Estrategia DOM | Shadow DOM nativo, sin diffing | LitElement gestiona Shadow DOM | Actualizaciones DOM disparadas por Zone | Bytecode compilado, renderizado incremental |
-| DI | Funciones factory explícitas | No incluida | Contenedor completo con decoradores | Árbol de componentes basado en propietario |
-| Tamaño del bundle | Sin deps en runtime | ~5 kB (lit-core) | Grande (framework) | Medio (standalone) |
-| SSR | Adopción HTML-first prerendered | Lit SSR (experimental) | Angular Universal | Glimmer SSR (Fastboot) |
-| Templates compilados en | Runtime (navegador) | Build time (template literals) | Build time (AOT) | Build time (bytecode) |
+| Aspecto | Pick Components | React | Vue | Lit | Angular | Svelte | Glimmer |
+| ------- | --------------- | ----- | --- | --- | ------- | ------ | ------- |
+| Modelo principal | Custom elements nativos | Librería UI sobre JSX + reconciliación | Framework progresivo sobre SFC + runtime reactivo | Librería de Web Components | Framework completo de aplicación | Componentes compiler-first | VM de renderizado de Ember |
+| Sintaxis de templates | `{{prop}}` en cadenas HTML | JSX | Templates SFC / funciones render | Template literals etiquetados | `{{ prop }}` en ficheros `.html` | Sintaxis de templates de Svelte | `{{prop}}` en ficheros `.hbs` |
+| Modelo de reactividad | Basado en señales, suscripciones por propiedad | Estado/hooks + reconciliación | Reactividad con proxies/refs | Reflexión de propiedades + ciclo de actualización | Zone.js + detección de cambios | Asignaciones reactivas en compilación | Referencias rastreadas + autotracking |
+| Estrategia DOM | Shadow DOM nativo, sin diffing | Diffing de Virtual DOM | Diffing de Virtual DOM | LitElement gestiona Shadow DOM | Actualizaciones DOM disparadas por Zone | Actualizaciones imperativas generadas por compilador | Bytecode compilado, renderizado incremental |
+| DI | Funciones factory explícitas | Librerías/patrones del ecosistema | Provide/inject + ecosistema | No incluida | Contenedor completo con decoradores | Manual/basada en módulos | Árbol de componentes basado en owner |
+| Requisito de build | Opcional (sin build para browser ESM plano; habitual con TS/decoradores) | Habitual | Habitual | Habitual | Flujo CLI/AOT requerido | Compilador requerido | Toolchain habitual de Ember/Glimmer |
+| SSR | Adopción HTML-first prerendered | Frameworks del ecosistema | Frameworks del ecosistema | Lit SSR (experimental) | Angular Universal | SvelteKit SSR | Glimmer SSR (Fastboot) |
+
+`Requisito de build` se refiere a si el framework exige compilación para poder ejecutarse. Pick Components puede ejecutarse directamente en el navegador con ESM y sin bundler; muchos proyectos igualmente usan build para TypeScript, decoradores y optimización.
 
 ---
 

--- a/docs/PICK-VS-OTHERS.md
+++ b/docs/PICK-VS-OTHERS.md
@@ -1,4 +1,4 @@
-# Pick Components vs Lit / Angular / Glimmer
+# Pick Components vs React / Vue / Lit / Angular / Svelte / Glimmer
 
 This document explains what Pick Components is and what it is not, to help developers coming from other frameworks set accurate expectations.
 
@@ -6,13 +6,31 @@ This document explains what Pick Components is and what it is not, to help devel
 
 ## What Pick Components is not
 
+### Not React
+
+React is a UI library centered around JSX, hook-based state, and reconciliation over a virtual component tree.
+
+Pick Components targets native custom elements directly. There is no framework-managed virtual tree between your component and the browser, and no hook runtime.
+
+That does not prevent coexistence inside a React app: Pick components can be consumed as custom elements in targeted screens without migrating the entire codebase.
+
+If React already gives your team speed and stability, staying there is usually the pragmatic choice; evaluate Pick only for specific use cases.
+
+### Not Vue
+
+Vue is a progressive framework with SFC conventions, a reactivity system based on refs/proxies, and app-level patterns for routing and stores.
+
+Pick Components does not define an SFC model or an app framework layer. It focuses on explicit native custom elements, explicit services, and predictable lifecycle factories.
+
+With an established Vue stack, case-by-case evaluation is usually more realistic than a broad migration.
+
 ### Not a Lit replacement
 
 Lit is a Google-maintained library for building Web Components with tagged template literals (`html\`...\``), property reflection, and a reactive update system that diffs attribute and property values.
 
 Pick Components does not use tagged template literals. Templates are plain HTML strings compiled into a reactive binding graph at runtime. The binding model is explicit and based on named state properties — there is no virtual DOM diffing and no property reflection cycle.
 
-If you are already using Lit and it meets your needs, there is no reason to switch.
+If Lit already fits your needs, continuing with Lit is a perfectly valid choice.
 
 ### Not Angular
 
@@ -20,11 +38,23 @@ Angular is a full application framework with a module system, dependency injecti
 
 Pick Components is a component framework, not an application framework. It has no router beyond `<pick-router>` for the simple case, no module system, no CLI, no AOT step, and no zone.js. Dependency injection is explicit and factory-first — there is no container that auto-discovers or auto-wires services.
 
+For teams invested in Angular CLI, DI, and ecosystem tooling, switching just to switch rarely pays off.
+
+### Not Svelte
+
+Svelte relies on compile-time transformations that rewrite component code and templates into imperative DOM operations.
+
+Pick Components does not require a compiler step. Templates are plain HTML strings interpreted at runtime by a deterministic binding engine, and component wiring stays explicit in factories and lifecycle hooks.
+
+If your workflow depends on Svelte's compiler advantages, staying with that model is often the sensible path.
+
 ### Not Glimmer
 
 Glimmer VM is the rendering layer inside Ember. It uses a compiled bytecode format for templates, a reference-based reactivity model, and a strict owner tree for component ownership.
 
 Pick Components compiles templates at runtime in the browser, not at build time. There is no bytecode, no Ember owner model, and no glimmer-component class contract to implement.
+
+In established Ember/Glimmer projects, Pick is usually better as a comparative reference than an immediate replacement.
 
 ---
 
@@ -60,15 +90,17 @@ The npm package has no runtime dependencies. The browser-ready distribution is a
 
 ## Quick comparison table
 
-| Aspect | Pick Components | Lit | Angular | Glimmer |
-| ------ | --------------- | --- | ------- | ------- |
-| Template syntax | `{{prop}}` in HTML strings | Tagged template literals | `{{ prop }}` in `.html` files | `{{prop}}` in `.hbs` files |
-| Reactivity model | Signal-based, per-property subscriptions | Property reflection + update cycle | Zone.js + change detection | Tracked references + autotracking |
-| DOM strategy | Native Shadow DOM, no diffing | LitElement manages Shadow DOM | Zone-triggered DOM updates | Compiled bytecode, incremental rendering |
-| DI | Explicit factory functions | Not included | Full container with decorators | Owner-based component tree |
-| Bundle size | Zero runtime deps | ~5 kB (lit-core) | Large (framework) | Medium (standalone) |
-| SSR | HTML-first prerender adoption | Lit SSR (experimental) | Angular Universal | Glimmer SSR (Fastboot) |
-| Templates compiled at | Runtime (browser) | Build time (tagged template literals) | Build time (AOT) | Build time (bytecode) |
+| Aspect | Pick Components | React | Vue | Lit | Angular | Svelte | Glimmer |
+| ------ | --------------- | ----- | --- | --- | ------- | ------ | ------- |
+| Primary model | Native custom elements | UI library around JSX + reconciliation | Progressive framework around SFC + reactive runtime | Web Components library | Full app framework | Compiler-first components | Ember rendering VM |
+| Template syntax | `{{prop}}` in HTML strings | JSX | SFC templates / render functions | Tagged template literals | `{{ prop }}` in `.html` files | Svelte template syntax | `{{prop}}` in `.hbs` files |
+| Reactivity model | Signal-based, per-property subscriptions | State/hooks + reconciliation | Proxy/ref-based reactivity | Property reflection + update cycle | Zone.js + change detection | Compile-time reactive assignments | Tracked references + autotracking |
+| DOM strategy | Native Shadow DOM, no diffing | Virtual DOM diffing | Virtual DOM diffing | LitElement manages Shadow DOM | Zone-triggered DOM updates | Compiler-generated imperative updates | Compiled bytecode, incremental rendering |
+| DI | Explicit factory functions | Library/ecosystem-driven | Provide/inject + ecosystem | Not included | Full container with decorators | Manual/module-based | Owner-based component tree |
+| Build requirement | Optional (no build needed for plain browser ESM; common for TS/decorators) | Typical | Typical | Typical | Required CLI/AOT flow | Required compiler | Typical Ember/Glimmer toolchain |
+| SSR | HTML-first prerender adoption | Ecosystem frameworks | Ecosystem frameworks | Lit SSR (experimental) | Angular Universal | SvelteKit SSR | Glimmer SSR (Fastboot) |
+
+`Build requirement` means whether the framework itself requires a compile/build pipeline to run. Pick Components can run directly in the browser with ESM and no bundler; many projects still choose a build step for TypeScript, decorators, and optimization.
 
 ---
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -5,6 +5,7 @@ Esta carpeta contiene la documentación canónica de Pick Components.
 ## Primeros Pasos
 
 - [WHY-PICK-COMPONENTS.md](WHY-PICK-COMPONENTS.md) - Motivación y origen del proyecto.
+- [WHY-PICK-COMPONENTS.es.md](WHY-PICK-COMPONENTS.es.md) - Traducción al español.
 - [GETTING-STARTED.md](GETTING-STARTED.md) - Guía paso a paso: proyecto → npm → skill → primer componente (EN).
 - [GETTING-STARTED.es.md](GETTING-STARTED.es.md) - Traducción al español.
 - [USAGE-GUIDE.md](USAGE-GUIDE.md) - Guía completa (EN) de setup, bootstrap, uso y playground.

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -8,6 +8,7 @@ Esta carpeta contiene la documentación canónica de Pick Components.
 - [GETTING-STARTED.md](GETTING-STARTED.md) - Guía paso a paso: proyecto → npm → skill → primer componente (EN).
 - [GETTING-STARTED.es.md](GETTING-STARTED.es.md) - Traducción al español.
 - [USAGE-GUIDE.md](USAGE-GUIDE.md) - Guía completa (EN) de setup, bootstrap, uso y playground.
+- [USAGE-GUIDE.es.md](USAGE-GUIDE.es.md) - Traducción al español.
 - [PICK-VS-PICKRENDER.md](PICK-VS-PICKRENDER.md) - Cuándo usar `@Pick` frente a `@PickRender`.
 - [PICK-VS-PICKRENDER.es.md](PICK-VS-PICKRENDER.es.md) - Traducción al español.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ This folder contains the canonical documentation for Pick Components.
 - [GETTING-STARTED.md](GETTING-STARTED.md) - Step-by-step guide: project → npm → skill → first component.
 - [GETTING-STARTED.es.md](GETTING-STARTED.es.md) - Spanish translation.
 - [USAGE-GUIDE.md](USAGE-GUIDE.md) - Full setup, bootstrap, usage examples, and playground workflow.
+- [USAGE-GUIDE.es.md](USAGE-GUIDE.es.md) - Spanish translation.
 - [PICK-VS-PICKRENDER.md](PICK-VS-PICKRENDER.md) - When to use `@Pick` vs `@PickRender`.
 - [PICK-VS-PICKRENDER.es.md](PICK-VS-PICKRENDER.es.md) - Spanish translation.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This folder contains the canonical documentation for Pick Components.
 ## Getting Started
 
 - [WHY-PICK-COMPONENTS.md](WHY-PICK-COMPONENTS.md) - Project motivation and origin story.
+- [WHY-PICK-COMPONENTS.es.md](WHY-PICK-COMPONENTS.es.md) - Spanish translation.
 - [GETTING-STARTED.md](GETTING-STARTED.md) - Step-by-step guide: project → npm → skill → first component.
 - [GETTING-STARTED.es.md](GETTING-STARTED.es.md) - Spanish translation.
 - [USAGE-GUIDE.md](USAGE-GUIDE.md) - Full setup, bootstrap, usage examples, and playground workflow.

--- a/docs/SEO.es.md
+++ b/docs/SEO.es.md
@@ -1,8 +1,8 @@
 # Entrega Compatible con SEO
 
-Pick Components soporta rutas publicas SEO-friendly con un modelo HTML-first. Las URLs publicas devuelven HTML completo y navegable, y el runtime del navegador mejora ese documento despues de cargar.
+Pick Components soporta rutas públicas SEO-friendly con un modelo HTML-first. Las URLs públicas devuelven HTML completo y navegable, y el runtime del navegador mejora ese documento después de cargar.
 
-La regla importante es que crawlers y navegadores reciben el mismo HTML canonico. La deteccion puede ajustar cache u observabilidad, pero no debe decidir si la pagina tiene contenido.
+La regla importante es que crawlers y navegadores reciben el mismo HTML canónico. La detección puede ajustar caché u observabilidad, pero no debe decidir si la página tiene contenido.
 
 ## Salida de Build
 
@@ -13,17 +13,17 @@ examples/es/<ruta>/index.html
 examples/en/<route>/index.html
 ```
 
-Cada pagina generada incluye:
+Cada página generada incluye:
 
 - enlaces canonical y alternate por idioma;
-- anchors reales de navegacion;
-- atributos del contrato de prerender para adopcion de DOM;
+- anchors reales de navegación;
+- atributos del contrato de prerender para adopción de DOM;
 - estado inicial serializado para el shell del playground;
 - el bundle cliente como enhancement progresivo.
 
 ## Entrega Local y Nginx
 
-Tanto el servidor de desarrollo como el servidor estatico de produccion usan rutas file-first:
+Tanto el servidor de desarrollo como el servidor estático de producción usan rutas file-first:
 
 ```text
 /es/01-hello
@@ -32,7 +32,7 @@ Tanto el servidor de desarrollo como el servidor estatico de produccion usan rut
   -> /index.html
 ```
 
-Los assets estaticos con extension no usan fallback SPA. Un `bundle.js` inexistente sigue siendo `404`, evitando que assets rotos devuelvan HTML por error.
+Los assets estáticos con extensión no usan fallback SPA. Un `bundle.js` inexistente sigue siendo `404`, evitando que assets rotos devuelvan HTML por error.
 
 Archivos relevantes:
 
@@ -42,14 +42,14 @@ Archivos relevantes:
 
 ## Docker
 
-La imagen Docker compila la libreria y los examples, y despues copia las rutas publicas generadas a Nginx:
+La imagen Docker compila la librería y los examples, y después copia las rutas públicas generadas a Nginx:
 
 ```bash
 docker build -t pick-components .
 docker run -p 8080:8080 pick-components
 ```
 
-Cuando el contenedor arranca, rutas publicas como `/es/01-hello` deben devolver directamente la pagina prerenderizada.
+Cuando el contenedor arranca, rutas públicas como `/es/01-hello` deben devolver directamente la página prerenderizada.
 
 ## Edge Worker
 
@@ -58,14 +58,14 @@ Para despliegues estilo Cloudflare Workers, usa:
 - `deploy/cloudflare/public-route-worker.mjs`
 - `deploy/cloudflare/wrangler.example.toml`
 
-El worker usa la misma politica que Nginx: HTML publico primero, shell SPA solo para rutas app-only, y ninguna rama de contenido especial para crawlers.
+El worker usa la misma política que Nginx: HTML público primero, shell SPA solo para rutas app-only, y ninguna rama de contenido especial para crawlers.
 
-## Adopcion en Runtime
+## Adopción en Runtime
 
-Las paginas generadas marcan los hosts prerenderizados con el contrato de prerender de Pick. En el primer arranque, el runtime comprueba version del contrato, selector, modo de root y hash del template. Si el markup es compatible, se adopta; si no, se usa el render normal como fallback.
+Las páginas generadas marcan los hosts prerenderizados con el contrato de prerender de Pick. En el primer arranque, el runtime comprueba versión del contrato, selector, modo de root y hash del template. Si el markup es compatible, se adopta; si no, se usa el render normal como fallback.
 
 ## Documentos Relacionados
 
 - Pick vs PickRender: [PICK-VS-PICKRENDER.es.md](PICK-VS-PICKRENDER.es.md)
 - Arquitectura de renderizado: [RENDERING-ARCHITECTURE.es.md](RENDERING-ARCHITECTURE.es.md)
-- Version en ingles: [SEO.md](SEO.md)
+- Versión en inglés: [SEO.md](SEO.md)

--- a/docs/USAGE-GUIDE.es.md
+++ b/docs/USAGE-GUIDE.es.md
@@ -42,7 +42,7 @@ HTML mínimo:
 
 ```html
 <!doctype html>
-<html lang="en">
+<html lang="es">
   <body>
     <hello-card></hello-card>
     <script type="module" src="./hello-card.js"></script>
@@ -215,7 +215,7 @@ await bootstrapFramework(Services, {}, {
 });
 ```
 
-Para la comparación profunda y guía de migración, consulta [PICK-VS-PICKRENDER.md](PICK-VS-PICKRENDER.md#using-without-decorators-definecomponent-and-definepick).
+Para la comparación profunda y guía de migración, consulta [PICK-VS-PICKRENDER.es.md](PICK-VS-PICKRENDER.es.md#sin-decoradores-definecomponent-y-definepick).
 
 ## Bootstrap
 

--- a/docs/USAGE-GUIDE.es.md
+++ b/docs/USAGE-GUIDE.es.md
@@ -1,0 +1,506 @@
+# Guía de Uso
+
+Esta guía contiene el contenido técnico ampliado que se movió desde el README raíz para mantener el onboarding rápido sin perder detalles completos de implementación.
+
+## Elige tu Setup
+
+### Opción A - npm + bundler
+
+Usa esta opción con Vite, Rollup, Webpack, esbuild o toolchains similares.
+
+```typescript
+import { bootstrapFramework, Services } from "pick-components";
+```
+
+Esta ruta no requiere específicamente Vite, pero sí un toolchain que pueda resolver imports del paquete npm para navegador.
+
+### Opción B - HTML plano + ESM listo para navegador
+
+Usa esta opción cuando quieras importar el framework directamente en el navegador, sin bundler.
+
+Para este modo, usa los artefactos browser-ready preparados para GitHub Releases en lugar de intentar importar el paquete npm directamente en el navegador.
+
+Los assets de release se publican aquí:
+
+- `https://github.com/pick-components/pick-components/releases`
+- `https://github.com/pick-components/pick-components/releases/tag/v<version>`
+
+Las URLs directas de assets siguen este patrón:
+
+- `https://github.com/pick-components/pick-components/releases/download/v<version>/pick-components.js`
+- `https://github.com/pick-components/pick-components/releases/download/v<version>/pick-components-bootstrap.js`
+
+Flujo recomendado:
+
+1. Descarga el bundle para navegador desde los assets de GitHub Release del proyecto.
+2. Cópialo en los assets públicos de tu sitio, por ejemplo `/vendor/pick-components.js`.
+3. Escribe el código del componente en TypeScript o JavaScript moderno.
+4. Transpílalo antes de servirlo al navegador.
+5. Importa el JavaScript generado desde tu HTML con `<script type="module">`.
+
+HTML mínimo:
+
+```html
+<!doctype html>
+<html lang="en">
+  <body>
+    <hello-card></hello-card>
+    <script type="module" src="./hello-card.js"></script>
+  </body>
+</html>
+```
+
+Fuente TypeScript mínima:
+
+```typescript
+import {
+  bootstrapFramework,
+  Services,
+  Pick,
+} from "/vendor/pick-components.js";
+
+await bootstrapFramework(Services);
+
+@Pick("hello-card", (ctx) => {
+  ctx.state({ name: "world" });
+  ctx.html(`<p>Hello {{name}}</p>`);
+})
+class HelloCard {}
+```
+
+La distribución browser-ready es autocontenida y no depende de paquetes runtime externos ni de builtins de Node. Está pensada para importarse directamente en el navegador una vez que el archivo se sirve desde tu sitio.
+
+El paquete npm está optimizado para desarrollo y consumo desde toolchains. La distribución para navegador plano está documentada y preparada como un flujo separado de artefactos de release, no como un entrypoint browser-importable del paquete npm.
+
+Para GitHub Releases, el proyecto también prepara una distribución de navegador más completa con:
+
+- bundles sin minificar
+- bundles minificados
+- source maps para todos los bundles de navegador
+- checksums SHA256
+
+Construye los artefactos de release localmente con:
+
+```bash
+npm run build:release
+```
+
+Esto crea `.release-artifacts/v<version>/`, que replica el contenido esperado en GitHub Release.
+
+Esta ruta de navegador directo asume un entorno moderno con ESM. La sintaxis TypeScript y los decoradores deben transpilarse salvo que tu runtime objetivo soporte explícitamente la sintaxis exacta de decoradores JavaScript que vayas a servir.
+
+## Adopción Incremental en Apps Existentes
+
+Pick Components se puede adoptar de forma incremental dentro de stacks frontend ya existentes.
+
+- En aplicaciones React/Vue, los componentes Pick pueden montarse como custom elements nativos en pantallas concretas.
+- No necesitas una reescritura completa para empezar; el enfoque de coexistencia está soportado.
+- Mantén el bootstrap de Pick explícito y aislado en el entry donde se usan esos custom elements.
+
+Enfoque típico por fases:
+
+1. Empieza con un widget autocontenido o una sección concreta de página.
+2. Registra solo los componentes Pick necesarios en ese entry.
+3. Amplía el uso solo si la integración aporta valor real a tu equipo.
+
+## Setup de Copilot AI (Opcional)
+
+Si quieres que Copilot siga las convenciones de Pick Components (componentes, DI, tests y templates), instala el skill del workspace en tu proyecto:
+
+```bash
+npx --package=pick-components pick-components-copilot
+```
+
+Esto copia `.github/skills/setup-pick-components/` en la raíz de tu proyecto. Haz commit del resultado para habilitar el skill en todo el equipo.
+
+Para instalar en un directorio específico:
+
+```bash
+npx --package=pick-components pick-components-copilot --target /path/to/your-project
+```
+
+Una vez instalado, escribe `/setup-pick-components` en el chat de Copilot para activar el skill.
+
+## TypeScript y Decoradores
+
+Pick Components funciona con ambos emits de decoradores de TypeScript:
+
+- Decoradores estándar: `experimentalDecorators` omitido o `false`.
+- Decoradores legacy: `experimentalDecorators: true`.
+
+No deberías tener que cambiar un proyecto Vite/TypeScript solo para usar Pick Components. El bootstrap por defecto acepta ambos modos.
+
+Sintaxis pública recomendada:
+
+```typescript
+class Counter extends PickComponent {
+  @Reactive count = 0;
+}
+```
+
+`@Reactive accessor count = 0` sigue soportado para quien quiera explícitamente auto-accessors TC39, pero no es obligatorio.
+
+El playground y los ejemplos descargados transpilan con esta forma de compilador:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "experimentalDecorators": false
+  }
+}
+```
+
+Si tu proyecto usa el pipeline `experimentalDecorators` de TypeScript, el bootstrap por defecto ya lo soporta:
+
+```typescript
+await bootstrapFramework(Services);
+```
+
+El modo estricto de decoradores solo está disponible cuando quieres aceptar intencionalmente solo decoradores estándar TC39:
+
+```typescript
+await bootstrapFramework(Services, {}, { decorators: "strict" });
+```
+
+Para una lista completa de combinaciones probadas de bundler y tsconfig, consulta [DECORATOR-COMPATIBILITY.md](DECORATOR-COMPATIBILITY.md).
+
+## Uso sin decoradores: `defineComponent` y `definePick`
+
+`defineComponent` y `definePick` son los equivalentes sin decoradores de `@PickRender` y `@Pick`. Devuelven descriptores `ComponentDefinition`, y el registro ocurre al pasar esos descriptores a `bootstrapFramework` mediante la opción `components`.
+
+### `defineComponent` - basado en clase, sin decorador de registro
+
+```typescript
+import { PickComponent, Reactive, defineComponent } from "pick-components";
+
+class CounterComponent extends PickComponent {
+  @Reactive count = 0;
+
+  increment(): void {
+    this.count++;
+  }
+}
+
+export const counterDef = defineComponent(CounterComponent, {
+  selector: "my-counter",
+  template: `
+    <p>{{count}}</p>
+    <pick-action action="increment"><button type="button">+1</button></pick-action>
+  `,
+});
+```
+
+### `definePick` - sin clase, sin decoradores
+
+```typescript
+import { definePick } from "pick-components";
+
+export const helloDef = definePick<{ name: string }>("hello-card", (ctx) => {
+  ctx.state({ name: "world" });
+  ctx.html(`<p>Hello {{name}}</p>`);
+});
+```
+
+### Registro explícito en `bootstrapFramework`
+
+```typescript
+import { bootstrapFramework, Services } from "pick-components";
+import { counterDef } from "./counter.js";
+import { helloDef } from "./hello.js";
+
+await bootstrapFramework(Services, {}, {
+  components: [counterDef, helloDef],
+});
+```
+
+Para la comparación profunda y guía de migración, consulta [PICK-VS-PICKRENDER.md](PICK-VS-PICKRENDER.md#using-without-decorators-definecomponent-and-definepick).
+
+## Bootstrap
+
+Llama a `bootstrapFramework()` una sola vez en tu entry point antes de que se evalúen módulos de componentes que usen `@Pick`, `@PickRender`, `@Reactive` o `@Listen`:
+
+```typescript
+import { bootstrapFramework, Services } from "pick-components";
+
+await bootstrapFramework(Services);
+await import("./my-component.js");
+```
+
+## Uso
+
+Los ejemplos de abajo usan la forma estándar de import del paquete:
+
+```typescript
+import { bootstrapFramework, Services } from "pick-components";
+
+await bootstrapFramework(Services);
+```
+
+### Componente Presentacional (Proyección de Slots)
+
+Componentes que envuelven contenido hijo en un layout con estilo usando slots nativos de Shadow DOM. Sin estado, sin lógica.
+
+```typescript
+import { Pick } from "pick-components";
+
+@Pick("card-container", (ctx) => {
+  ctx.html(`
+    <div class="card">
+      <div class="card-header">
+        <slot name="header">Default Header</slot>
+      </div>
+      <div class="card-body">
+        <slot>Default Content</slot>
+      </div>
+    </div>
+  `);
+})
+export class CardContainer {}
+```
+
+```html
+<card-container>
+  <h2 slot="header">Card Title</h2>
+  <p>Card body content goes here.</p>
+</card-container>
+```
+
+### Componente de Datos (Props Reactivas)
+
+Componentes que reciben datos por atributos y los renderizan de forma reactiva.
+
+```typescript
+import { Pick } from "pick-components";
+
+@Pick("user-badge", (ctx) => {
+  ctx.props<{ name: string; role: string }>();
+
+  ctx.html(`
+    <div class="badge">
+      <span class="name">{{name}}</span>
+      <span class="role">{{role}}</span>
+    </div>
+  `);
+})
+export class UserBadge {}
+```
+
+```html
+<user-badge name="Alice" role="Engineer"></user-badge>
+```
+
+### Componente Interactivo (Estado Local + Eventos)
+
+Componentes con estado local que responde a interacciones de usuario.
+
+```typescript
+import { Pick } from "pick-components";
+
+@Pick("simple-counter", (ctx) => {
+  ctx.state({ count: 0 });
+
+  ctx.on({
+    increment() {
+      this.count++;
+    },
+    decrement() {
+      this.count--;
+    },
+    reset() {
+      this.count = 0;
+    },
+  });
+
+  ctx.html(`
+    <div class="counter">
+      <pick-action action="decrement"><button type="button">-</button></pick-action>
+      <span>{{count}}</span>
+      <pick-action action="increment"><button type="button">+</button></pick-action>
+      <pick-action action="reset"><button type="button">Reset</button></pick-action>
+    </div>
+  `);
+})
+export class SimpleCounter {}
+```
+
+### Componente Basado en Clase (`@PickRender`)
+
+Para componentes que necesitan inicialización asíncrona o un lifecycle manager para conectar servicios externos.
+
+```typescript
+import {
+  PickRender,
+  PickComponent,
+  PickInitializer,
+  PickLifecycleManager,
+  Reactive,
+} from "pick-components";
+
+class TodoInitializer extends PickInitializer<TodoList> {
+  protected async onInitialize(component: TodoList): Promise<boolean> {
+    component.items = await fetch("/api/todos").then((r) => r.json());
+    return true;
+  }
+}
+
+class TodoLifecycle extends PickLifecycleManager<TodoList> {
+  protected onComponentReady(component: TodoList): void {
+    this.addSubscription(
+      todoService.onUpdate$.subscribe((items) => {
+        component.items = items;
+      }),
+    );
+  }
+}
+
+@PickRender({
+  selector: "todo-list",
+  template: `
+    <ul>
+      <pick-for items="{{items}}" key="id">
+        <li class="{{$item.done ? 'done' : ''}}">{{$item.text}}</li>
+      </pick-for>
+    </ul>
+  `,
+  initializer: () => new TodoInitializer(),
+  lifecycle: () => new TodoLifecycle(),
+})
+export class TodoList extends PickComponent {
+  @Reactive items: Todo[] = [];
+}
+```
+
+## Seguridad de Templates
+
+Pick Components valida templates estáticos en tiempo de compilación. Inline event handlers, elementos ejecutables, `srcdoc`, `style`, `srcset` y protocolos URL inseguros se rechazan con errores explícitos. Las expresiones de template se evalúan mediante un parser restringido y los bindings dinámicos de URL se verifican por la política de attribute binding. Los templates son código escrito por desarrolladores, pero aun así se validan para que sigan siendo declarativos y no se conviertan en entornos ocultos de ejecución JavaScript.
+
+Verificación manual: un template con `<img src="x" onerror="this.insertAdjacentHTML('afterend', '<strong id=xss-ok>ONERROR EJECUTADO</strong>')">` debe fallar al renderizar con un error claro de Pick Components. `ONERROR EJECUTADO` no debe aparecer.
+
+## Intenciones de Componente
+
+Usa `@Reactive` para estado que se renderiza. Usa signals de intención para acciones one-shot de usuario como guardar, refrescar o cambiar de modo, que un lifecycle manager pueda coordinar con servicios.
+
+```typescript
+class ModeSelector extends PickComponent {
+  @Reactive mode: RaceMode = "mass_start";
+
+  readonly modeRequested$ = this.createIntent<RaceMode>();
+
+  requestMode(mode: RaceMode): void {
+    this.modeRequested$.notify(mode);
+  }
+}
+
+class ModeSelectorLifecycle extends PickLifecycleManager<ModeSelector> {
+  protected onComponentReady(component: ModeSelector): void {
+    this.addSubscription(
+      component.modeRequested$.subscribe((mode) => {
+        raceService.setMode(mode);
+      }),
+    );
+  }
+}
+```
+
+`@Pick` tiene la misma capacidad mediante `ctx.intent<T>("name$")`. Prefiere este patrón para acciones y comandos; deja `getPropertyObservable()` para cambios reales de estado.
+
+## Acciones de Vista
+
+`<pick-action>` es el puente declarativo entre el markup de vista y las acciones del componente. Escucha activación por click y teclado sobre su contenido hijo, y luego despacha un evento `pick-action` que maneja el PickComponent más cercano.
+
+```html
+<pick-action action="archive" value="{{selectedId}}">
+  <button type="button">Archive</button>
+</pick-action>
+```
+
+- `action` es el nombre de acción expuesto por `ctx.on(...)` o `getViewActions()`.
+- `value` es opcional y se convierte en el primer argumento de la acción.
+- El hijo puede ser cualquier trigger visual, no solo un `<button>`.
+- `event` también se acepta como alias de `action`, pero el código nuevo debe usar `action`.
+- Las acciones manejadas se detienen en el componente más cercano por defecto.
+- Añade `bubble` solo cuando un componente padre deba poder manejar la misma acción.
+
+## Sintaxis de Templates
+
+| Sintaxis          | Descripción                                               |
+| ----------------- | --------------------------------------------------------- |
+| `{{expression}}`  | Binding reactivo - se reevalúa al cambiar la propiedad   |
+| `[[RULES.field]]` | Reglas de validación - expande a atributos HTML5         |
+| `<slot>`          | Slot de proyección por defecto (Shadow DOM nativo)       |
+| `<slot name="X">` | Slot de proyección con nombre (Shadow DOM nativo)      |
+
+## Comandos
+
+| Comando                    | Descripción                                                       |
+| -------------------------- | ----------------------------------------------------------------- |
+| `npm install`              | Instalar dependencias                                             |
+| `npm run build:lib`        | Compilar librería a `dist/`                                       |
+| `npm run build:browser`    | Empaquetar artefactos ESM browser-ready en `dist/browser/`        |
+| `npm run build:prod`       | Compilar librería + artefactos ESM browser-ready                  |
+| `npm run build:release`    | Preparar artefactos browser de release en `.release-artifacts/`   |
+| `npm run build`            | Compilar librería + ejemplos                                      |
+| `npm run serve:dev`        | Iniciar servidor dev en `http://localhost:3000`                   |
+| `npm run serve:dist`       | Servir ejemplos compilados con rutas SEO file-first en puerto `8080` |
+| `npm test`                 | Ejecutar suite completa (unit + integration)                      |
+| `npm run test:unit`        | Solo tests unitarios                                              |
+| `npm run test:integration` | Solo tests de integración                                         |
+| `npm run test:coverage`    | Ejecutar unit + integration con umbral V8 del 80%                |
+| `npm run lint`             | Ejecutar lint en fuentes                                          |
+| `npm run format`           | Formatear fuentes                                                 |
+
+## Playground Interactivo
+
+El proyecto incluye 15 ejemplos interactivos que corren en navegador mediante un playground TypeScript con preview en vivo. Cada ejemplo tiene un panel de código editable (CodeMirror) y un sandbox iframe que retranspila y reejecuta en cada cambio.
+
+Pruébalo online: <https://pick-components.github.io/pick-components/>
+
+### Ejecutar el playground
+
+```bash
+npm install
+npm run build
+npm run serve:dev
+```
+
+Para previsualizar los ejemplos compilados con el servidor estático orientado a producción:
+
+```bash
+npm run build
+npm run serve:dist
+```
+
+El playground también incluye una plantilla edge worker en `deploy/cloudflare/public-route-worker.mjs`. Sirve primero rutas públicas prerenderizadas y luego hace fallback al shell SPA para rutas solo de app. Crawlers y navegadores reciben el mismo HTML canónico; el bundle cliente solo lo mejora.
+
+### Ejemplos
+
+| #   | Pestaña                  | Categoría     | Descripción                                      |
+| --- | ------------------------ | ------------ | ------------------------------------------------ |
+| 01  | Hello World              | Basics       | Componente mínimo con `@PickRender`             |
+| 02  | Reactive State           | Basics       | Estado `@Reactive` y acciones simples           |
+| 03  | Template Bindings        | Basics       | Bindings simples con `{{...}}`                  |
+| 04  | Template Expressions     | Basics       | Expresiones dentro de `{{...}}`                 |
+| 05  | Computed Bindings        | Basics       | Bindings derivados de getters                   |
+| 06  | @Pick Component          | Basics       | Autoría funcional con `@Pick`                   |
+| 07  | Pick Actions             | Primitives   | Acciones declarativas de vista con `<pick-action>` |
+| 07b | Pick Actions with @Pick  | Primitives   | El mismo modelo de acciones vía `ctx.on(...)`   |
+| 08  | Pick Select              | Primitives   | Ramas condicionales con `<pick-select>`         |
+| 09  | Pick For                 | Primitives   | Renderizado de listas con `<pick-for>`          |
+| 10  | Forms and Rules          | Primitives   | Reglas de validación provistas antes de render  |
+| 11  | DI Injection             | Architecture | Puente InjectKit y dependencias por constructor |
+| 12  | Real API                 | Architecture | Initializer + lifecycle + `createIntent()`      |
+| 13  | Dashboard                | Architecture | Composición multi-servicio y template/CSS separados |
+| 14  | @Pick Advanced           | Architecture | Componente `@Pick` completo con servicios y estado |
+| 15  | Native Slots             | Basics       | Proyección nativa de slots con nombre y por defecto |
+
+### Despliegue con Docker
+
+```bash
+docker build -t pick-components .
+docker run -p 8080:8080 pick-components
+```
+
+- Playground: `http://localhost:8080`
+- Rutas públicas: `http://localhost:8080/es/01-hello`

--- a/docs/USAGE-GUIDE.md
+++ b/docs/USAGE-GUIDE.md
@@ -89,6 +89,20 @@ This creates `.release-artifacts/v<version>/`, which mirrors the intended GitHub
 
 This direct browser path assumes a modern browser environment with ESM. TypeScript syntax and decorators must still be transpiled unless your target runtime explicitly supports the exact JavaScript decorator syntax you are serving.
 
+## Incremental Adoption in Existing Apps
+
+Pick Components can be adopted incrementally inside existing frontend stacks.
+
+- In React/Vue applications, Pick components can be mounted as native custom elements in selected screens.
+- You do not need a full rewrite to start; a coexistence approach is supported.
+- Keep Pick bootstrap explicit and isolated in the entry where those custom elements are used.
+
+Typical phased approach:
+
+1. Start with one self-contained widget or page section.
+2. Register only the needed Pick components in that entry.
+3. Expand usage only if the integration proves valuable for your team.
+
 ## Copilot AI Setup (Optional)
 
 If you want Copilot to follow Pick Components conventions (components, DI, tests, and templates), install the workspace skill into your project:

--- a/docs/WHY-PICK-COMPONENTS.es.md
+++ b/docs/WHY-PICK-COMPONENTS.es.md
@@ -1,0 +1,15 @@
+# Por Qué Existe Pick Components
+
+No trabajo a tiempo completo en el frontend web. Pero de vez en cuando termino construyendo algo para la web — un proyecto personal, algo pequeño o una herramienta para un amigo — y cada vez que entro en ese mundo tengo la misma sensación: demasiadas capas, demasiados frameworks, demasiadas librerías apiladas unas sobre otras, y muy poca sensación de poder ver el proyecto de extremo a extremo. Llega un punto en el que sientes que algo no encaja.
+
+Pick Components nació de esa sensación. No nació de "quiero construir otro framework", y desde luego no nació de querer competir con React, Angular o Vue. Nació de querer algo útil para mis propios proyectos: una forma de construir Web Components nativos con límites más claros, templates controlados y menos dependencia de runtimes grandes.
+
+Esta idea es anterior a este repositorio. Hace más de cinco años, en `FieldDocumentMaker`, dentro de `FieldDocumentMaker.Editor/src/components`, tenía un componente base que ya contenía la primera forma, todavía tosca, de esta idea. Una cosa que descubrí desarrollando ese proyecto fue que, en JavaScript, `a.b` y `a["b"]` son dos formas de llegar a la misma propiedad. Eso cambió mi forma de pensar en cómo trabaja la UI: menos "ejecuta código aquí" y más "resuelve esto desde la estructura".
+
+Aquel componente antiguo ya tenía versiones tempranas de ideas que luego se volvieron centrales en este proyecto: bindings de template `{{...}}`, bindings basados en propiedades, actualizaciones reactivas del DOM y un pequeño paso de compilación de DOM/template. Lo que todavía faltaba era una arquitectura más limpia y una línea más firme sobre aquello a lo que los templates deberían limitarse.
+
+Con el tiempo, eso se convirtió en una regla de diseño. Quería expresiones en templates, pero no quería `eval`, `new Function` ni JavaScript arbitrario ejecutándose dentro de templates. Esa decisión empujó el proyecto hacia parsear un lenguaje de expresiones limitado, construir un AST y evaluarlo bajo reglas explícitas. Gran parte de lo que hoy es Pick Components viene de tomarse en serio esa idea, en lugar de tratar los templates como un lugar donde vale todo.
+
+Los modelos de lenguaje me ayudaron mucho durante todo el desarrollo. No solo como generadores de código — que también lo fueron, y de forma valiosísima —, sino para explorar arquitectura, probar ideas, refactorizar, formalizar intuiciones difusas y acelerar implementación y documentación. La dirección seguía teniendo que salir de mí, pero hicieron mucho más fácil iterar sobre el diseño del framework.
+
+Por eso construí Pick Components: para crear Web Components nativos con una arquitectura interna más explícita, templates controlados, estado reactivo, un lifecycle claro y menos dependencia de runtimes grandes. Si esto te resulta útil, pruébalo, lee el código, cuestiona el diseño, abre issues y contribuye si quieres ayudar a darle forma.


### PR DESCRIPTION
## Resumen
Esta PR amplía y mejora la documentación de Pick Components con foco en:

- Cobertura en español (incluyendo guía de uso completa).
- Claridad en comparación con otros frameworks.
- Guía explícita de adopción incremental en apps existentes (coexistencia con React/Vue).
- Mejoras de navegación entre índices y README.
- Alineación del changelog en Unreleased.

## Cambios principales

### 1) Nueva guía en español
- Se añade USAGE-GUIDE.es.md con paridad funcional respecto a la guía en inglés.

### 2) Índices de documentación actualizados
- Se agrega enlace a la nueva guía en:
- README.md
- README.es.md

### 3) README raíz: mejor acceso a docs en español
- Se añaden enlaces directos a rutas ES en:
- README.md

### 4) Comparativas de frameworks refinadas (EN/ES)
- Se amplía y ajusta el contenido en:
- PICK-VS-OTHERS.md
- PICK-VS-OTHERS.es.md
- Mejor diferenciación entre React y Vue.
- Mensajes de convivencia/adopción incremental (sin forzar migración total).
- Redacción menos repetitiva entre secciones.

### 5) DI documentada con más precisión (EN/ES)
- Se documenta explícitamente:
- Services.get como lazy singleton para factories.
- Services.getNew como transient (instancia nueva por llamada).
- Archivos:
- DEPENDENCY-INJECTION.md
- DEPENDENCY-INJECTION.es.md

### 6) Guías de inicio y uso con enfoque de integración incremental
- Se incorporan notas/patrones para integrar Pick en apps existentes (React/Vue) en:
- GETTING-STARTED.md
- GETTING-STARTED.es.md
- USAGE-GUIDE.md

### 7) Skill de Copilot ajustado
- Se añaden patrones/prompt de integración incremental en:
- 01-create-components.md

### 8) Changelog
- Se actualiza Unreleased en:
- CHANGELOG.md

## Impacto
- Solo documentación y skill prompts.
- Sin cambios funcionales de runtime ni API pública de la librería.

## Validación
- Revisión manual de enlaces internos y consistencia EN/ES.
- Confirmado acceso a nuevas rutas de documentación en índices y README.