### PR TITLE
feat: expose IComponentHostResolver as minimal public host-resolver contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `docs/GETTING-STARTED.md`, `docs/GETTING-STARTED.es.md`, and `docs/USAGE-GUIDE.md` with incremental-adoption guidance for integrating Pick Components into existing React/Vue applications.
 - Updated `.github/skills/setup-pick-components/01-create-components.md` with incremental integration prompt patterns for existing frontend applications.
 
+## [1.0.9] - 2026-05-12
+
+### Added
+- Added `IComponentHostResolver` as a minimal public interface exposing only `resolve(component: PickComponent): HTMLElement`, intended for consumer and user-space code.
+- Registered `"IComponentHostResolver"` as a service alias in the bootstrap, so consumers can use `Services.get<IComponentHostResolver>("IComponentHostResolver")` with a matching token. `"IHostResolver"` is preserved for backward compatibility.
+
+### Changed
+- `IHostResolver` now extends `IComponentHostResolver` and no longer declares `clear()`, which was dead code.
+- Removed `clear()` from `DomContextHostResolver` implementation.
+- `DomContextHostResolver` updated: `PickComponent` types throughout, `WeakMap` key narrowed from `object` to `PickComponent`.
+- Updated playground `code-playground.pick.ts` to use the typed `IComponentHostResolver` import instead of an inline anonymous type.
+
 ## [1.0.8] - 2026-05-10
 
 ### Added

--- a/examples/src/features/playground/components/code-playground.pick.ts
+++ b/examples/src/features/playground/components/code-playground.pick.ts
@@ -1,4 +1,4 @@
-import { PickComponent, PickRender, Reactive, Services } from "pick-components";
+import { PickComponent, PickRender, Reactive, Services, type IComponentHostResolver } from "pick-components";
 import { CodePlaygroundInitializer } from "../initializers/code-playground.initializer.js";
 import { CodePlaygroundLifecycle } from "../lifecycles/code-playground.lifecycle.js";
 
@@ -263,9 +263,7 @@ export class CodePlayground extends PickComponent {
     }
 
     try {
-      const hostResolver = Services.get<{
-        resolve(target: object): HTMLElement;
-      }>("IHostResolver");
+      const hostResolver = Services.get<IComponentHostResolver>("IComponentHostResolver");
       return hostResolver.resolve(this);
     } catch {
       return null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ export type {
   IRenderEngine,
 } from "./rendering/index.js";
 export { DomContext } from "./rendering/dom-context/dom-context.js";
+export type { IComponentHostResolver } from "./rendering/dom-context/component-host-resolver.interface.js";
 export { SharedStylesRegistry } from "./rendering/styles/shared-styles-registry.js";
 export type { ISharedStylesRegistry } from "./rendering/styles/shared-styles-registry.js";
 // ScopeStack and fragment AST path removed from public API

--- a/src/providers/framework-bootstrap.ts
+++ b/src/providers/framework-bootstrap.ts
@@ -226,6 +226,7 @@ export async function bootstrapFramework(
 
   // Host resolution
   register("IHostResolver", () => new DomContextHostResolver());
+  register("IComponentHostResolver", () => registry.get("IHostResolver"));
 
   // Expression parsing
   register("IExpressionParser", () => new ExpressionParserService());

--- a/src/rendering/dom-context/component-host-resolver.interface.ts
+++ b/src/rendering/dom-context/component-host-resolver.interface.ts
@@ -1,0 +1,28 @@
+import type { PickComponent } from "../../core/pick-component.js";
+
+/**
+ * Defines the responsibility of resolving the host element for a component instance.
+ *
+ * @description
+ * Minimal public contract for accessing the host HTMLElement of a registered
+ * component. This interface is intended for consumption from component code
+ * and user-space services. Internal lifecycle methods (`register`, `unregister`)
+ * are intentionally excluded.
+ *
+ * @example
+ * ```typescript
+ * const resolver = Services.get<IComponentHostResolver>("IComponentHostResolver");
+ * const host = resolver.resolve(this);
+ * host.scrollIntoView();
+ * ```
+ */
+export interface IComponentHostResolver {
+  /**
+   * Resolves the host element for a component instance.
+   *
+   * @param component - Component instance
+   * @returns The host HTMLElement
+   * @throws Error if component is not registered
+   */
+  resolve(component: PickComponent): HTMLElement;
+}

--- a/src/rendering/dom-context/dom-context-host-resolver.ts
+++ b/src/rendering/dom-context/dom-context-host-resolver.ts
@@ -1,5 +1,6 @@
 import type { IDomContext } from "./dom-context.interface.js";
 import type { IHostResolver } from "./host-resolver.interface.js";
+import type { PickComponent } from "../../core/pick-component.js";
 
 /**
  * Implements the responsibility of resolving host elements via DomContext.
@@ -24,7 +25,7 @@ import type { IHostResolver } from "./host-resolver.interface.js";
  * ```
  */
 export class DomContextHostResolver implements IHostResolver {
-  private contextMap = new WeakMap<object, IDomContext>();
+  private contextMap = new WeakMap<PickComponent, IDomContext>();
 
   /**
    * Registers a component with its DOM context.
@@ -33,7 +34,7 @@ export class DomContextHostResolver implements IHostResolver {
    * @param domContext - Associated DOM context
    * @throws Error if component or domContext is null/undefined
    */
-  register(component: object, domContext: IDomContext): void {
+  register(component: PickComponent, domContext: IDomContext): void {
     if (!component || typeof component !== "object") {
       throw new Error("Component is required");
     }
@@ -50,7 +51,7 @@ export class DomContextHostResolver implements IHostResolver {
    * @returns The host HTMLElement from associated DomContext
    * @throws Error if component is not registered
    */
-  resolve(component: object): HTMLElement {
+  resolve(component: PickComponent): HTMLElement {
     if (!component || typeof component !== "object") {
       throw new Error("Component is required");
     }
@@ -86,19 +87,11 @@ export class DomContextHostResolver implements IHostResolver {
    *
    * @param component - Component instance to unregister
    */
-  unregister(component: object): void {
+  unregister(component: PickComponent): void {
     if (!component || typeof component !== "object") {
       return;
     }
     this.contextMap.delete(component);
   }
 
-  /**
-   * Clears all registered components.
-   * Primarily for testing to ensure test isolation.
-   */
-  clear(): void {
-    // WeakMap doesn't have a clear method, but we can create a new one
-    this.contextMap = new WeakMap<object, IDomContext>();
-  }
 }

--- a/src/rendering/dom-context/host-resolver.interface.ts
+++ b/src/rendering/dom-context/host-resolver.interface.ts
@@ -1,12 +1,14 @@
-import type { IDomContext } from "../dom-context/dom-context.interface.js";
+import type { IComponentHostResolver } from "./component-host-resolver.interface.js";
+import type { IDomContext } from "./dom-context.interface.js";
+import type { PickComponent } from "../../core/pick-component.js";
 
 /**
  * Defines the responsibility of resolving host elements for components.
  *
  * @description
- * Abstracts the mechanism for locating the DOM host element associated
- * with a component instance or DOM context. Enables lifecycle managers
- * to access the host without direct coupling to DomContext.
+ * Internal framework contract for managing component-to-DomContext associations.
+ * Extends {@link IComponentHostResolver} with lifecycle methods used by the
+ * render pipeline. Consumer code should depend on `IComponentHostResolver` instead.
  *
  * @example
  * ```typescript
@@ -17,34 +19,19 @@ import type { IDomContext } from "../dom-context/dom-context.interface.js";
  * host.appendChild(element);
  * ```
  */
-export interface IHostResolver {
+export interface IHostResolver extends IComponentHostResolver {
   /**
    * Registers a component with its associated DOM context.
    *
    * @param component - Component instance
    * @param domContext - Associated DOM context
    */
-  register(component: object, domContext: IDomContext): void;
-
-  /**
-   * Resolves the host element for a component instance.
-   *
-   * @param component - Component instance
-   * @returns The host HTMLElement
-   * @throws Error if component is not registered
-   */
-  resolve(component: object): HTMLElement;
+  register(component: PickComponent, domContext: IDomContext): void;
 
   /**
    * Unregisters a component from the resolver.
    *
    * @param component - Component instance to unregister
    */
-  unregister(component: object): void;
-
-  /**
-   * Clears all registered components.
-   * Used for testing to ensure test isolation.
-   */
-  clear(): void;
+  unregister(component: PickComponent): void;
 }

--- a/tests/unit/providers/framework-bootstrap.test.ts
+++ b/tests/unit/providers/framework-bootstrap.test.ts
@@ -85,6 +85,7 @@ test.describe("bootstrapFramework", () => {
       "IComponentMetadataRegistry",
       "IComponentInstanceRegistry",
       "IHostResolver",
+      "IComponentHostResolver",
       "IExpressionParser",
       "IEvaluator",
       "IExpressionResolver",
@@ -113,6 +114,19 @@ test.describe("bootstrapFramework", () => {
     for (const token of expectedTokens) {
       expect(mock.has(token)).toBe(true);
     }
+  });
+
+  test("should register IComponentHostResolver as an alias of IHostResolver", async () => {
+    // Arrange
+    const mock = createMockServiceRegistry();
+
+    // Act
+    await bootstrapFramework(mock as any);
+
+    // Assert
+    const hostResolver = mock.get("IHostResolver");
+    const componentHostResolver = mock.get("IComponentHostResolver");
+    expect(componentHostResolver).toStrictEqual(hostResolver);
   });
 
   test("should default decorator compatibility mode to auto", async () => {


### PR DESCRIPTION
Introduce IComponentHostResolver, a public interface that exposes only resolve(component: PickComponent): HTMLElement, for use from component and user-space code. The internal IHostResolver extends it and retains register/unregister for pipeline use.

- Add src/rendering/dom-context/component-host-resolver.interface.ts
- IHostResolver extends IComponentHostResolver; clear() removed (dead code)
- DomContextHostResolver updated: PickComponent types throughout, WeakMap key narrowed
- Export IComponentHostResolver from the library public API (src/index.ts)
- Playground code-playground.pick.ts imports IComponentHostResolver instead of inline anonymous type

Closes no issue; part of 1.0.9 release.